### PR TITLE
OLH-2970: Set up to deploy dev platform stacks

### DIFF
--- a/infra/api_gateway_logs.tf
+++ b/infra/api_gateway_logs.tf
@@ -1,0 +1,7 @@
+resource "aws_cloudformation_stack" "api_gateway_logs_stack" {
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377037345/API+gateway+logging
+  name         = "api-gateway-logs"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/api-gateway-logs/template.yaml"
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/audit_hooks.tf
+++ b/infra/audit_hooks.tf
@@ -1,0 +1,17 @@
+resource "aws_cloudformation_stack" "lambda_audit_hook_stack" {
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3376906289/Lambda+audit+hook
+  provider     = aws.london
+  name         = "lambda-audit-hook"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/lambda-audit-hook/template.yaml"
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}
+
+resource "aws_cloudformation_stack" "infrastructure_audit_hook_stack" {
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3375464940/Infrastructure+audit+hook
+  provider     = aws.london
+  name         = "infrastructure-audit-hook"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/infrastructure-audit-hook/template.yaml"
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/audit_hooks.tf
+++ b/infra/audit_hooks.tf
@@ -1,6 +1,5 @@
 resource "aws_cloudformation_stack" "lambda_audit_hook_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3376906289/Lambda+audit+hook
-  provider     = aws.london
   name         = "lambda-audit-hook"
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/lambda-audit-hook/template.yaml"
 
@@ -9,7 +8,6 @@ resource "aws_cloudformation_stack" "lambda_audit_hook_stack" {
 
 resource "aws_cloudformation_stack" "infrastructure_audit_hook_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3375464940/Infrastructure+audit+hook
-  provider     = aws.london
   name         = "infrastructure-audit-hook"
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/infrastructure-audit-hook/template.yaml"
 

--- a/infra/build_notifications.tf
+++ b/infra/build_notifications.tf
@@ -1,6 +1,5 @@
 resource "aws_cloudformation_stack" "build_notifications_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377168419/Slack+build+notifications+-+via+AWS+Chatbot
-  provider     = aws.london
   name         = "build-notifications"
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/build-notifications/template.yaml"
 

--- a/infra/build_notifications.tf
+++ b/infra/build_notifications.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudformation_stack" "build_notifications_stack" {
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377168419/Slack+build+notifications+-+via+AWS+Chatbot
+  provider     = aws.london
+  name         = "build-notifications"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/build-notifications/template.yaml"
+
+  parameters = {
+    InitialNotificationStack = "Yes"
+    SlackChannelId           = var.environment == "production" ? "C04D3SQNJ4B" : "C083UQKHPC2"
+    EnrichedNotifications    = "True"
+  }
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/certificate_expiry.tf
+++ b/infra/certificate_expiry.tf
@@ -1,0 +1,11 @@
+resource "aws_cloudformation_stack" "certificate_expiry_stack" {
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3374843054/Certificate+Expiry
+  name         = "certificate-expiry"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate-expiry/template.yaml"
+
+  parameters = {
+    DaysBeforeExpiry = 45
+  }
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/ecr_scan_logger.tf
+++ b/infra/ecr_scan_logger.tf
@@ -1,0 +1,12 @@
+resource "aws_cloudformation_stack" "ecr_scan_logger_stack" {
+  count = var.create_build_stacks ? 1 : 0
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377102896/ECR+Scan+Result+Logger
+  name         = "ecr-image-scan-findings-logger"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/ecr-image-scan-findings-logger/template.yaml"
+
+  parameters = {
+    NotificationEmail = var.notification_email
+  }
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/ecr_scan_logger.tf
+++ b/infra/ecr_scan_logger.tf
@@ -5,7 +5,7 @@ resource "aws_cloudformation_stack" "ecr_scan_logger_stack" {
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/ecr-image-scan-findings-logger/template.yaml"
 
   parameters = {
-    NotificationEmail = var.notification_email
+    NotificationEmail = var.owner_email
   }
 
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]

--- a/infra/github_identity_provider.tf
+++ b/infra/github_identity_provider.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudformation_stack" "github_identity_provider_stack" {
+  count = var.create_build_stacks ? 1 : 0
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3375464923/GitHub+Identity+Provider
+  provider     = aws.london
+  name         = "github-identity-provider"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/github-identity/template.yaml"
+
+  parameters = {
+    Environment = var.environment
+    System      = "Account Management Components"
+  }
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/github_identity_provider.tf
+++ b/infra/github_identity_provider.tf
@@ -7,7 +7,7 @@ resource "aws_cloudformation_stack" "github_identity_provider_stack" {
 
   parameters = {
     Environment = var.environment
-    System      = "Account Management Components"
+    System      = var.system
   }
 
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]

--- a/infra/github_identity_provider.tf
+++ b/infra/github_identity_provider.tf
@@ -1,7 +1,6 @@
 resource "aws_cloudformation_stack" "github_identity_provider_stack" {
   count = var.create_build_stacks ? 1 : 0
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3375464923/GitHub+Identity+Provider
-  provider     = aws.london
   name         = "github-identity-provider"
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/github-identity/template.yaml"
 

--- a/infra/signer.tf
+++ b/infra/signer.tf
@@ -11,3 +11,17 @@ resource "aws_cloudformation_stack" "signer_stack" {
 
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
 }
+
+resource "aws_cloudformation_stack" "container_signer_stack" {
+  count = var.create_build_stacks ? 1 : 0
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3376840727/Container+Signer
+  name         = "signer"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/container-signer/template.yaml"
+
+  parameters = {
+    Environment     = var.environment
+    AllowedAccounts = join(",", var.signer_allowed_accounts)
+  }
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/signer.tf
+++ b/infra/signer.tf
@@ -7,7 +7,7 @@ resource "aws_cloudformation_stack" "signer_stack" {
 
   parameters = {
     Environment = var.environment
-    System      = "Account Management Components"
+    System      = var.system
   }
 
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]

--- a/infra/signer.tf
+++ b/infra/signer.tf
@@ -1,0 +1,14 @@
+resource "aws_cloudformation_stack" "signer_stack" {
+  count = var.create_build_stacks ? 1 : 0
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377004573/AWS+Signer
+  provider     = aws.london
+  name         = "signer"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/signer/template.yaml"
+
+  parameters = {
+    Environment = var.environment
+    System      = "Account Management Components"
+  }
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}

--- a/infra/signer.tf
+++ b/infra/signer.tf
@@ -1,7 +1,6 @@
 resource "aws_cloudformation_stack" "signer_stack" {
   count = var.create_build_stacks ? 1 : 0
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377004573/AWS+Signer
-  provider     = aws.london
   name         = "signer"
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/signer/template.yaml"
 

--- a/infra/site.tf
+++ b/infra/site.tf
@@ -13,4 +13,13 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      Product     = var.product
+      System      = var.system
+      Environment = var.environment
+      Owner       = var.owner_email
+    }
+  }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -23,3 +23,9 @@ variable "system" {
   description = "The name of the system. Used in tags."
   default     = "Account Managment Components"
 }
+
+
+variable "signer_allowed_accounts" {
+  type        = list(string)
+  description = "The AWS account IDs that can read the code signing KMS key. "
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -3,7 +3,7 @@ variable "environment" {
   description = "The environment name"
   validation {
     condition     = contains(["dev", "build", "staging", "integration", "production"], var.environment)
-    error_message = "Valid values for var: environment are (dev, build, staging, integration, production)."
+    error_message = "Valid values for var: environment are (dev, build, staging, integration, production)"
   }
 }
 
@@ -14,7 +14,7 @@ variable "hosted_zone_domain" {
 
 variable "create_build_stacks" {
   type        = bool
-  description = "Whether or not to deploy the stacks for building and signing application code. Only needed in dev and build. Defaults to false."
+  description = "Whether or not to deploy the stacks for building and signing application code. Only needed in dev and build. Defaults to false"
   default     = false
 }
 
@@ -27,5 +27,10 @@ variable "system" {
 
 variable "signer_allowed_accounts" {
   type        = list(string)
-  description = "The AWS account IDs that can read the code signing KMS key. "
+  description = "The AWS account IDs that can read the code signing KMS key"
+}
+
+variable "notification_email" {
+  type        = string
+  description = "The email address to send ECR image vulnerabilities to"
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,4 +1,19 @@
+variable "environment" {
+  type        = string
+  description = "The environment name"
+  validation {
+    condition     = contains(["dev", "build", "staging", "integration", "production"], var.environment)
+    error_message = "Valid values for var: environment are (dev, build, staging, integration, production)."
+  }
+}
+
 variable "hosted_zone_domain" {
   type        = string
   description = "The base domain to use for the account's hosted zone"
+}
+
+variable "create_build_stacks" {
+  type        = bool
+  description = "Whether or not to deploy the stacks for building and signing application code. Only needed in dev and build. Defaults to false."
+  default     = false
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -17,3 +17,9 @@ variable "create_build_stacks" {
   description = "Whether or not to deploy the stacks for building and signing application code. Only needed in dev and build. Defaults to false."
   default     = false
 }
+
+variable "system" {
+  type        = string
+  description = "The name of the system. Used in tags."
+  default     = "Account Managment Components"
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -21,7 +21,13 @@ variable "create_build_stacks" {
 variable "system" {
   type        = string
   description = "The name of the system. Used in tags."
-  default     = "Account Managment Components"
+  default     = "Account Management Components"
+}
+
+variable "product" {
+  type        = string
+  description = "The name of the product. Used in tags."
+  default     = "GOV.UK One Login"
 }
 
 
@@ -30,7 +36,7 @@ variable "signer_allowed_accounts" {
   description = "The AWS account IDs that can read the code signing KMS key"
 }
 
-variable "notification_email" {
+variable "owner_email" {
   type        = string
-  description = "The email address to send ECR image vulnerabilities to"
+  description = "The owning team's Google Group email address. Used for tagging and ECR scan notifications"
 }

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,6 +1,5 @@
 resource "aws_cloudformation_stack" "vpc_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3531735041/VPC
-  provider     = aws.london
   name         = "vpc"
   template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/vpc/template.yaml"
 

--- a/infra/vpc.tf
+++ b/infra/vpc.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudformation_stack" "vpc_stack" {
+  # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3531735041/VPC
+  provider     = aws.london
+  name         = "vpc"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/vpc/template.yaml"
+
+  parameters = {
+    CloudWatchApiEnabled = "Yes"
+    DynatraceApiEnabled  = "Yes"
+    KMSApiEnabled        = "Yes"
+    AllowRules           = "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\"account.gov.uk\"; endswith; msg:\"Pass TLS to *.account.gov.uk\"; flow:established; sid:2001; rev:1;)"
+    AllowedDomains       = "*.account.gov.uk"
+  }
+
+  capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
+}


### PR DESCRIPTION
Set up to deploy all the core dev platform stacks to our AWS accounts. This PR doesn't include the variables for each environment as we'll need some of the outputs from eg. build before we can deploy in staging. 

This will deploy the following stacks to every AWS account:
- VPC
- Build notifications
- Lambda audit hook
- Infrastructure audit hook 
- API Gateway logging
- Certificate expiry notifications

Additionally in build-like environments (will just be build and dev for us now) it'll deploy:
- Code signer
- Container signer
- ECR scan notifications

Deploying these extra stacks is controlled by a variable so we'll just need to set that to `true` when we deploy to dev and build.

Before we can apply this Terraform to our accounts we'll need to do the manual authentication steps for the Slack notifications as [detailed in the stack docs](https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377168419/Slack+build+notifications+-+via+AWS+Chatbot#Grant-AWS-Chatbot-access-to-Slack).

We'll also need to deploy to build first then populate the staging `.tfvars` file with the appropriate stack output values, then repeat for subsequent environments. I'll write up a separate ticket that details exactly what to do. 