### PR TITLE
OLH-2977: Add action to deploy the PoC app to dev

### DIFF
--- a/.github/workflows/deploy-app-to-dev.yaml
+++ b/.github/workflows/deploy-app-to-dev.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a
         with:
-          role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }} # TODO remove DEV_
+          role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: "eu-west-2"
 
       - name: Install dependencies
@@ -85,6 +85,6 @@ jobs:
       - name: Deploy app
         uses: govuk-one-login/devplatform-upload-action@fda75612a1b0e5a8c84ae7c44a23340e50e5bbde
         with:
-          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME }} # TODO remove DEV_
-          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }} # TODO remove DEV_
+          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
           working-directory: ./projects/app


### PR DESCRIPTION
This is triggered manually to deploy a commit, tag or branch. I've lifted the input and choice sections from the equivalent actions on the Frontend.