### PR TITLE
Add a noop workflow, so that we can test the ones on a branch

### DIFF
--- a/.github/workflows/publish-integration-tests-image.yaml
+++ b/.github/workflows/publish-integration-tests-image.yaml
@@ -1,0 +1,10 @@
+name: Publish integration tests image
+on:
+  workflow_dispatch:
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No operation
+        run: echo "This workflow is triggered manually to publish the integration tests image"


### PR DESCRIPTION
In order to run a workflow from a branch, there needs to be a workflow on the `main` branch

This PR will add a workflow that doesn't do anything, so that we can trigger the workflow through the UI whilst we develop it.