### PR TITLE
BAU: add depend eslint plugin

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,7 @@ import vitestEslint from "@vitest/eslint-plugin";
 import nodeEslint from "eslint-plugin-n";
 import playwrightEslint from "eslint-plugin-playwright";
 import { defineConfig } from "eslint/config";
+import dependEslint from "eslint-plugin-depend";
 
 // eslint-disable-next-line no-restricted-exports
 export default defineConfig(
@@ -24,7 +25,8 @@ export default defineConfig(
   tseslint.configs.strictTypeChecked,
   tseslint.configs.stylisticTypeChecked,
   {
-    plugins: { n: nodeEslint },
+    plugins: { n: nodeEslint, depend: dependEslint },
+    extends: ["depend/flat/recommended"],
     rules: {
       "no-console": "error",
       "@typescript-eslint/consistent-type-imports": "error",
@@ -50,6 +52,12 @@ export default defineConfig(
           "ts-expect-error": "allow-with-description",
           "ts-ignore": true,
           "ts-nocheck": true,
+        },
+      ],
+      "depend/ban-dependencies": [
+        "error",
+        {
+          allowed: ["dotenv"],
         },
       ],
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "csso-cli": "^4.0.2",
         "dotenv": "^17.2.2",
         "eslint": "^9.35.0",
+        "eslint-plugin-depend": "^1.2.0",
         "eslint-plugin-n": "^17.22.0",
         "eslint-plugin-playwright": "^2.2.2",
         "fastify-cli": "^7.4.0",
@@ -5321,6 +5322,35 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-plugin-depend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-depend/-/eslint-plugin-depend-1.2.0.tgz",
+      "integrity": "sha512-nbG8AOTYk43kM/SLCFLNW8tvAssF3rrvE5W5dWLP9/joNdAvzJLMuTEx9GIahoRYVTFCQYLejg2tll0USSvFHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fd-package-json": "^1.2.0",
+        "module-replacements": "^2.8.0",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/eslint-plugin-depend/node_modules/fd-package-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fd-package-json/-/fd-package-json-1.2.0.tgz",
+      "integrity": "sha512-45LSPmWf+gC5tdCQMNH4s9Sr00bIkiD9aN7dc5hqkrEw1geRYyDQS1v1oMHAW3ysfxfndqGsrDREHHjNNbKUfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "walk-up-path": "^3.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-depend/node_modules/walk-up-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
+      "integrity": "sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/eslint-plugin-es-x": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
@@ -7603,6 +7633,13 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/module-replacements": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/module-replacements/-/module-replacements-2.9.0.tgz",
+      "integrity": "sha512-Huqvn/LX14pkuMroDdYNzqSpFbyIneAZX+/y9qaVr3++Eo/CTm/PZKhLbwwJCPaZDL/ia/xSV492N2jPNuvfcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "csso-cli": "^4.0.2",
     "dotenv": "^17.2.2",
     "eslint": "^9.35.0",
+    "eslint-plugin-depend": "^1.2.0",
     "eslint-plugin-n": "^17.22.0",
     "eslint-plugin-playwright": "^2.2.2",
     "fastify-cli": "^7.4.0",


### PR DESCRIPTION
Adds the [eslint-plugin-depend](https://github.com/es-tooling/eslint-plugin-depend) plugin which will help suggest alternatives to various dependencies. Primarily, it will help detect dependency tree bloat and redundant polyfills.

Allowlists `dotenv` as we have a good use case for using it, and we only use it in local dev environments.