### PR TITLE
OLH-3154: Set up the core stack and deploy a DynamoDB SSE key

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -56,6 +56,9 @@ jobs:
       - name: SAM validate app
         run: npm run sam-validate:app
 
+      - name: SAM validate core
+        run: npm run sam-validate:core
+
       - name: Lint CloudFormation
         run: npm run cfnlint
 

--- a/.github/workflows/deploy-core-to-dev.yaml
+++ b/.github/workflows/deploy-core-to-dev.yaml
@@ -1,0 +1,77 @@
+name: Deploy app to dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      refType:
+        type: choice
+        description: "Find branch name, commit SHA, or tag?"
+        options:
+          - Branch name
+          - Commit SHA
+          - Tag
+        default: Branch name
+      gitRef:
+        description: "Input branch name, commit SHA, or tag"
+        required: true
+        type: string
+        default: main
+
+jobs:
+  deploy-core-to-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.gitRef }}
+
+      - name: Set commit SHA
+        if: github.event.inputs.refType == 'Commit SHA'
+        run: echo GIT_REF_SHA=${GIT_REF} >> $GITHUB_ENV
+        env:
+          GIT_REF: ${{ inputs.gitRef }}
+
+      - name: Set commit SHA by branch name
+        if: github.event.inputs.refType == 'Branch name'
+        run: echo GIT_REF_SHA=$(git log -1 ${GIT_REF} --pretty=format:%H) >> $GITHUB_ENV
+        env:
+          GIT_REF: ${{ inputs.gitRef }}
+
+      - name: Set commit SHA by tag
+        if: github.event.inputs.refType == 'Tag'
+        run: echo GIT_REF_SHA=$(git rev-list -n 1 ${GIT_REF}) >> $GITHUB_ENV
+        env:
+          GIT_REF: ${{ inputs.gitRef }}
+
+      - name: Set tag
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
+      - name: Set current datetime
+        run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
+
+      - name: Set up SAM CLI
+        uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63
+        with:
+          use-installer: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838
+        with:
+          role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN_CORE }}
+          aws-region: "eu-west-2"
+
+      - name: Build SAM template
+        run: cd ./projects/core && sam build
+
+      - name: Deploy core
+        uses: govuk-one-login/devplatform-upload-action@fda75612a1b0e5a8c84ae7c44a23340e50e5bbde
+        with:
+          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME_CORE }}
+          signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+          working-directory: ./projects/app

--- a/.github/workflows/deploy-core-to-dev.yaml
+++ b/.github/workflows/deploy-core-to-dev.yaml
@@ -1,4 +1,4 @@
-name: Deploy app to dev
+name: Deploy core to dev
 
 on:
   workflow_dispatch:
@@ -74,4 +74,4 @@ jobs:
         with:
           artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME_CORE }}
           signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
-          working-directory: ./projects/app
+          working-directory: ./projects/core

--- a/.github/workflows/deploy-core.yaml
+++ b/.github/workflows/deploy-core.yaml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - projects/core/**
+      - .github/workflows/deploy-core.yaml
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/deploy-core.yaml
+++ b/.github/workflows/deploy-core.yaml
@@ -1,0 +1,46 @@
+name: Deploy core
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-core:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+
+      - name: Set up SAM CLI
+        uses: aws-actions/setup-sam@f664fad9e12492edfc187a31f575537dfbb0ff63
+        with:
+          use-installer: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838
+        with:
+          role-to-assume: ${{ secrets.GH_ACTIONS_ROLE_ARN_CORE }}
+          aws-region: "eu-west-2"
+
+      - name: Build SAM template
+        run: cd ./projects/core && sam build
+
+      - name: Deploy core
+        uses: govuk-one-login/devplatform-upload-action@fda75612a1b0e5a8c84ae7c44a23340e50e5bbde
+        with:
+          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME_CORE }}
+          signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
+          working-directory: ./projects/core

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,11 @@ coverage
 .env*
 !.env*.sample
 !.env.openapi
+.aws-sam
 
 projects/app/dist
 projects/app/dist_openapi
 projects/app/openapi_check*.yaml
-
-projects/core/.aws-sam
 
 projects/infra/.terraform
 projects/infra/.terraform.lock.hcl

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ projects/app/dist
 projects/app/dist_openapi
 projects/app/openapi_check*.yaml
 
+projects/core/.aws-sam
+
 projects/infra/.terraform
 projects/infra/.terraform.lock.hcl
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,16 @@ repos:
 
   - repo: local
     hooks:
+      - id: sam-validate-core
+        name: SAM validate core
+        entry: npm run sam-validate:core
+        language: system
+        exclude: .*
+        always_run: true
+        stages: [pre-commit]
+
+  - repo: local
+    hooks:
       - id: cfnlint
         name: Lint CloudFormation
         entry: npm run cfnlint

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "check-gh-actions": "zizmor .",
     "check-gh-actions:fix": "zizmor . --fix",
     "sam-validate:app": "cd projects/app && sam validate --region eu-west-2 --lint",
+    "sam-validate:core": "cd projects/core && sam validate --region eu-west-2 --lint",
     "build:app:shared": "cd projects/app && rm -rf dist && cp -r ./src ./dist && find dist -type f ! -name '*.njk' -print0 | xargs -0 rm -f && cp -r ./src/static dist && sass dist/static/shared-cache/application.scss dist/static/shared-cache/application.css --no-source-map && rm dist/static/shared-cache/application.scss && csso dist/static/shared-cache/application.css --output dist/static/shared-cache/application.css",
     "build:app": "npm run build:app:shared && cd projects/app && rolldown -c rolldown.config.ts && cp ./Makefile dist && cp ../../package.json ./dist/package.json",
     "build-local:app": "npm run build:app:shared && cd projects/app && rolldown -c rolldown.local.config.ts",

--- a/projects/core/template.yaml
+++ b/projects/core/template.yaml
@@ -1,0 +1,77 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Environment:
+    Type: String
+    Description: >
+      The environment type
+    AllowedValues:
+      - "dev"
+      - "build"
+      - "staging"
+      - "integration"
+      - "production"
+  CodeSigningConfigArn:
+    Type: String
+    Description: >
+      The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Default: "none"
+  PermissionsBoundary:
+    Type: String
+    Description: >
+      The ARN of the permissions boundary to apply to any role created by the template, provided by the deployment pipeline
+    Default: "none"
+  VpcStackName:
+    Type: String
+    Description: >
+      The name of the stack that defines the VPC in which resources will be located, provided by the deployment pipeline
+
+Resources:
+  DynamoDbSSEKey:
+    Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Description: AWS KMS key for encrypting the data stored within DynamoDB tables
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: "dynamodb.amazonaws.com"
+            Action:
+              - "kms:Encrypt"
+              - "kms:Decrypt"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:DescribeKey"
+              - "kms:CreateGrant"
+            Resource: "*"
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-DynamoDbSSEKey"
+
+  DynamoDbSSEKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/${AWS::StackName}-DynamoDbSSEKey"
+      TargetKeyId: !GetAtt DynamoDbSSEKey.Arn
+
+  DynamoDbSSEKeyArnSSM:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Description: "The ARN of the DynamoDbSSEKey KMS key"
+      Name: !Sub "/${AWS::StackName}/KMS/DynamoDbSSEKey/ARN"
+      Type: String
+      Value: !GetAtt DynamoDbSSEKey.Arn


### PR DESCRIPTION
This PR sets up the file structure, Github actions and linting checks for the core stack, then deploys a KMS key into it which we'll use for server side encryption on all our DynamoDB tables. 

I'm pretty confident this is the full list of permissions required on the key, but we don't have a DynamoDB table to check it with yet so it's hard to test. It'll be easier to fix forward any issues which do come up.