### PR TITLE
OLH-3149 Add UserInfo Table

### DIFF
--- a/projects/core/template.yaml
+++ b/projects/core/template.yaml
@@ -75,3 +75,35 @@ Resources:
       Name: !Sub "/${AWS::StackName}/KMS/DynamoDbSSEKey/ARN"
       Type: String
       Value: !GetAtt DynamoDbSSEKey.Arn
+
+  UserInfoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: "user_info"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: outcome_id
+          AttributeType: S
+        - AttributeName: outcome_type
+          AttributeType: S
+        - AttributeName: access_token
+          AttributeType: S
+      KeySchema:
+        - AttributeName: outcome_id
+          KeyType: HASH
+        - AttributeName: outcome_type
+          KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: AccessTokenIndex
+          KeySchema:
+            - AttributeName: access_token
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+      SSESpecification:
+        KMSMasterKeyId: !GetAtt DynamoDbSSEKey.Arn
+        SSEEnabled: true
+        SSEType: KMS
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-user_info"


### PR DESCRIPTION
This PR adds the UserInfo table, with the required indexes, and uses the KMS key for encryption.

I have verified that after deploying to dev, the table is created