### PR TITLE
OLH-3152 add replay attack prevention table

### DIFF
--- a/projects/app/template.yaml
+++ b/projects/app/template.yaml
@@ -238,6 +238,36 @@ Resources:
         SSEType: KMS
       TableClass: STANDARD
 
+  ReplayAttackTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      TableName: !Sub ${AWS::StackName}-ReplayAttack
+      AttributeDefinitions:
+        - AttributeName: nonce
+          AttributeType: S
+      KeySchema:
+        - AttributeName: nonce
+          KeyType: HASH
+      TimeToLiveSpecification:
+        AttributeName: expires
+        Enabled: true
+      BillingMode: PAY_PER_REQUEST
+      ContributorInsightsSpecification:
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+      SSESpecification:
+        KMSMasterKeyId:
+          Fn::ImportValue: !Sub "${CoreStackName}:DynamoDbSSEKeyArn"
+        SSEEnabled: true
+        SSEType: KMS
+      TableClass: STANDARD
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-replay_attack"
+
   AppPublicApiGateway:
     Type: AWS::Serverless::Api
     Properties:


### PR DESCRIPTION
This PR adds a Relay attack table, which stores a nonce in a database so we can check that it hasn't already been used