### PR TITLE
OLH-3250 - Add VPCE Endpoint for SSM on Account Components and Perms for Lambda to access SSM 

### DIFF
--- a/solutions/infra/vpc.tf
+++ b/solutions/infra/vpc.tf
@@ -7,6 +7,7 @@ resource "aws_cloudformation_stack" "vpc_stack" {
     CloudWatchApiEnabled     = "Yes"
     DynatraceApiEnabled      = "Yes"
     KMSApiEnabled            = "Yes"
+    SSMApiEnabled            = "Yes"
     AllowRules               = "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\"account.gov.uk\"; endswith; msg:\"Pass TLS to *.account.gov.uk\"; flow:established; sid:2001; rev:1;)"
     AllowedDomains           = "*.account.gov.uk"
     ExecuteApiGatewayEnabled = "Yes"

--- a/solutions/localstack/provision.sh
+++ b/solutions/localstack/provision.sh
@@ -169,8 +169,27 @@ create_dynamodb_tables() {
 
 list_resources() {
   echo "List resources"
+  ENDPOINT_URL="http://localhost:4566"
 
-  aws --endpoint-url=http://localhost:4566 ssm describe-parameters
+  # List all parameter names
+  PARAM_NAMES=$(aws ssm describe-parameters \
+    --endpoint-url "$ENDPOINT_URL" \
+    --query "Parameters[*].Name" \
+    --output text)
+
+  echo "Listing SSM parameters from LocalStack..."
+
+  for NAME in $PARAM_NAMES; do
+    VALUE=$(aws ssm get-parameter \
+      --endpoint-url "$ENDPOINT_URL" \
+      --name "$NAME" \
+      --with-decryption \
+      --query "Parameter.Value" \
+      --output text)
+
+    echo "$NAME = $VALUE"
+  done
+
   aws --endpoint-url=http://localhost:4566 dynamodb list-tables
   return 0
 }

--- a/solutions/stubs/template.yaml
+++ b/solutions/stubs/template.yaml
@@ -126,33 +126,6 @@ Globals:
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
 
 Resources:
-  StubsLambdaEnvironmentVariablesEncryptionKey:
-    Type: AWS::KMS::Key
-    Properties:
-      Description: KMS key used to encrypt lambda environment variables
-      EnableKeyRotation: true
-      KeyPolicy:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action:
-              - kms:*
-            Resource: "*"
-          - Effect: "Allow"
-            Principal:
-              Service: lambda.amazonaws.com
-            Action:
-              - "kms:Decrypt"
-            Resource: "*"
-            Condition:
-              ArnLike:
-                "aws:SourceArn": !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*"
-      Tags:
-        - Key: Name
-          Value: !Sub "${AWS::StackName}-StubsLambdaEnvironmentVariablesEncryptionKey"
-
   StubECPrivateKeySSM:
     Type: AWS::SSM::Parameter
     Properties:
@@ -193,6 +166,71 @@ Resources:
       Tags:
         Environment: !Ref Environment
 
+  StubsLambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Ref GetSSMParameterPolicy
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+
+  GetSSMParameterPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+              - ssm:GetParameters
+              - ssm:GetParametersByPath
+            Resource:
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/RsaPublicKey
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/RsaPrivateKey
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/EcPublicKey
+              - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/EcPrivateKey
+
+  StubsLambdaEnvironmentVariablesEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS key used to encrypt lambda environment variables
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: "Allow"
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - "kms:Decrypt"
+            Resource: "*"
+            Condition:
+              ArnLike:
+                "aws:SourceArn": !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*"
+      Tags:
+        - Key: Name
+          Value: !Sub "${AWS::StackName}-StubsLambdaEnvironmentVariablesEncryptionKey"
+
   StubsApiGateway:
     Type: AWS::Serverless::Api
     Properties:
@@ -232,6 +270,7 @@ Resources:
           RSA_PRIVATE_KEY_SSM_NAME: !Sub "/${AWS::StackName}/RsaPrivateKey"
           EC_PUBLIC_KEY_SSM_NAME: !Sub "/${AWS::StackName}/EcPublicKey"
           RSA_PUBLIC_KEY_SSM_NAME: !Sub "/${AWS::StackName}/RsaPublicKey"
+      Role: !GetAtt StubsLambdaExecutionRole.Arn
 
   StubsLambdaLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Proposed changes

OLH-3250 - Add VPCE Endpoint for SSM on Account Components and Perms for Lambda to access SSM

### What changed

Updated VPC terraform to enable SSM API
Updated cloud formation template to give stubs lambda permission to get SSM parameter

### Why did it change

So that create mock request object endpoint can execute successfully in dev by punching a whole in VPC to access SSM params and give permission to use SSM

### Related links


## Checklists

### Environment variables or secrets


### Testing
Ensure deployment to dev is successful
Test ability go call the endpoint and view generated JAR in dev environment
Unpack signed and generated jar
Verify access token

### Sign-offs

## How to review