### PR TITLE
OLH-3240: fix stubs deploys

### DIFF
--- a/.github/workflows/deploy-stubs-to-dev.yaml
+++ b/.github/workflows/deploy-stubs-to-dev.yaml
@@ -84,6 +84,6 @@ jobs:
       - name: Deploy stubs
         uses: govuk-one-login/devplatform-upload-action@fda75612a1b0e5a8c84ae7c44a23340e50e5bbde
         with:
-          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME }}
+          artifact-bucket-name: ${{ secrets.DEV_ARTIFACT_BUCKET_NAME_MOCKS }}
           signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
           working-directory: ./solutions/stubs

--- a/.github/workflows/deploy-stubs.yaml
+++ b/.github/workflows/deploy-stubs.yaml
@@ -57,6 +57,6 @@ jobs:
       - name: Deploy stubs
         uses: govuk-one-login/devplatform-upload-action@fda75612a1b0e5a8c84ae7c44a23340e50e5bbde
         with:
-          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME }}
+          artifact-bucket-name: ${{ secrets.ARTIFACT_BUCKET_NAME_MOCKS }}
           signing-profile-name: ${{ secrets.SIGNING_PROFILE_NAME }}
           working-directory: ./solutions/stubs


### PR DESCRIPTION
Use the correct bucket name secrets in stub deployment GitHub Actions so that stub deployments actually work