### PR TITLE
OLH-4017: use dynamic imports for route handlers

### DIFF
--- a/solutions/frontend/src/journeys/index.test.ts
+++ b/solutions/frontend/src/journeys/index.test.ts
@@ -7,8 +7,9 @@ import type { FastifyInstance } from "fastify";
 import { testingJourney } from "./testing-journey/index.js";
 import { onRequest } from "./utils/onRequest.js";
 import { onSend } from "./utils/onSend.js";
-import { completeFailedJourneyHandler } from "./completeFailedJourney/handler.js";
 import { paths } from "../utils/paths.js";
+
+const mockCompleteFailedJourneyHandler = vi.fn();
 
 vi.mock(import("./utils/onRequest.js"), () => ({
   onRequest: vi.fn(),
@@ -17,7 +18,7 @@ vi.mock(import("./utils/onSend.js"), () => ({
   onSend: vi.fn(),
 }));
 vi.mock(import("./completeFailedJourney/handler.js"), () => ({
-  completeFailedJourneyHandler: vi.fn(),
+  completeFailedJourneyHandler: mockCompleteFailedJourneyHandler,
 }));
 
 describe("journeyRoutes plugin", () => {
@@ -102,16 +103,53 @@ describe("journeyRoutes plugin", () => {
     expect(mockRegister).toHaveBeenCalledWith(passkeyCreate);
   });
 
-  it("registers completeFailedJourneyHandler routes", () => {
+  it("registers GET route for completeFailedJourney", () => {
     journeyRoutes(mockFastify);
 
     expect(mockGet).toHaveBeenCalledWith(
       paths.journeys.others.completeFailedJourney.path,
-      completeFailedJourneyHandler,
+      expect.any(Function),
     );
+  });
+
+  it("registers POST route for completeFailedJourney", () => {
+    journeyRoutes(mockFastify);
+
     expect(mockPost).toHaveBeenCalledWith(
       paths.journeys.others.completeFailedJourney.path,
-      completeFailedJourneyHandler,
+      expect.any(Function),
+    );
+  });
+
+  it("calls completeFailedJourneyHandler via dynamic import for GET route", async () => {
+    journeyRoutes(mockFastify);
+
+    const getHandler = mockGet.mock.calls.find(
+      (call) => call[0] === paths.journeys.others.completeFailedJourney.path,
+    )?.[1];
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    await getHandler(mockRequest, mockReply);
+
+    expect(mockCompleteFailedJourneyHandler).toHaveBeenCalledWith(
+      mockRequest,
+      mockReply,
+    );
+  });
+
+  it("calls completeFailedJourneyHandler via dynamic import for POST route", async () => {
+    journeyRoutes(mockFastify);
+
+    const postHandler = mockPost.mock.calls.find(
+      (call) => call[0] === paths.journeys.others.completeFailedJourney.path,
+    )?.[1];
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    await postHandler(mockRequest, mockReply);
+
+    expect(mockCompleteFailedJourneyHandler).toHaveBeenCalledWith(
+      mockRequest,
+      mockReply,
     );
   });
 });

--- a/solutions/frontend/src/journeys/index.ts
+++ b/solutions/frontend/src/journeys/index.ts
@@ -4,7 +4,6 @@ import { accountDelete } from "./account-delete/index.js";
 import { passkeyCreate } from "./passkey-create/index.js";
 import { onRequest } from "./utils/onRequest.js";
 import { onSend } from "./utils/onSend.js";
-import { completeFailedJourneyHandler } from "./completeFailedJourney/handler.js";
 import { paths } from "../utils/paths.js";
 
 export const journeyRoutes = function (fastify: FastifyInstance) {
@@ -18,11 +17,19 @@ export const journeyRoutes = function (fastify: FastifyInstance) {
 
   fastify.get(
     paths.journeys.others.completeFailedJourney.path,
-    completeFailedJourneyHandler,
+    async function (request, reply) {
+      return (
+        await import("./completeFailedJourney/handler.js")
+      ).completeFailedJourneyHandler(request, reply);
+    },
   );
   fastify.post(
     paths.journeys.others.completeFailedJourney.path,
-    completeFailedJourneyHandler,
+    async function (request, reply) {
+      return (
+        await import("./completeFailedJourney/handler.js")
+      ).completeFailedJourneyHandler(request, reply);
+    },
   );
   fastify.register(testingJourney);
   fastify.register(accountDelete);


### PR DESCRIPTION
Use dynamic imports for the complete failed journey route handlers so they're only loaded on demand.