### PR TITLE
OLH-4059: Notify send email stub

### DIFF
--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -2871,6 +2871,12 @@ Resources:
           API_BASE_URL: !Sub "https://${ApiApiGateway}.execute-api.${AWS::Region}.amazonaws.com/${ApiStageName}"
           ROOT_DOMAIN:
             !FindInMap [EnvironmentConfiguration, !Ref Environment, rootDomain]
+          NOTIFY_TEMPLATE_IDS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              notifyTemplateIds,
+            ]
       Policies:
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
         - Statement:

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -78,7 +78,7 @@ Mappings:
       securityUrl: https://home.dev.account.gov.uk/security
       dynatraceRumUrl: ""
       accountDataApiUrl: https://stubs.manage.dev.account.gov.uk/account-data-api
-      notifySendEmailStubUrl: https://stubs.manage.dev.account.gov.uk/notify/send-email
+      notifyStubUrl: https://stubs.manage.dev.account.gov.uk/notify
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "e85e22eb-ab14-4881-8334-5e51ac46b08f",
@@ -112,7 +112,7 @@ Mappings:
       securityUrl: https://home.build.account.gov.uk/security
       dynatraceRumUrl: ""
       accountDataApiUrl: https://stubs.manage.build.account.gov.uk/account-data-api
-      notifySendEmailStubUrl: https://stubs.manage.build.account.gov.uk/notify/send-email
+      notifyStubUrl: https://stubs.manage.build.account.gov.uk/notify
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "e85e22eb-ab14-4881-8334-5e51ac46b08f",
@@ -148,7 +148,7 @@ Mappings:
       securityUrl: https://home.staging.account.gov.uk/security
       dynatraceRumUrl: TODO
       accountDataApiUrl: https://7xgl7lexy4.execute-api.eu-west-2.amazonaws.com/staging
-      notifySendEmailStubUrl: ""
+      notifyStubUrl: ""
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "e85e22eb-ab14-4881-8334-5e51ac46b08f",
@@ -184,7 +184,7 @@ Mappings:
       securityUrl: https://home.integration.account.gov.uk/security
       dynatraceRumUrl: TODO
       accountDataApiUrl: https://hoidt6wujb.execute-api.eu-west-2.amazonaws.com/integration
-      notifySendEmailStubUrl: ""
+      notifyStubUrl: ""
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "a37858f1-45e5-4b9f-8d93-efbbc955ffbf",
@@ -220,7 +220,7 @@ Mappings:
       securityUrl: https://home.account.gov.uk/security
       dynatraceRumUrl: TODO
       accountDataApiUrl: https://0218o1p9tj.execute-api.eu-west-2.amazonaws.com/production
-      notifySendEmailStubUrl: ""
+      notifyStubUrl: ""
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "a37858f1-45e5-4b9f-8d93-efbbc955ffbf",
@@ -1003,11 +1003,11 @@ Resources:
               !Ref Environment,
               notifyTemplateIds,
             ]
-          NOTIFY_SEND_EMAIL_STUB_URL:
+          NOTIFY_STUB_URL:
             !FindInMap [
               EnvironmentConfiguration,
               !Ref Environment,
-              notifySendEmailStubUrl,
+              notifyStubUrl,
             ]
       DeploymentPreference:
         Alarms: !If

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -78,6 +78,7 @@ Mappings:
       securityUrl: https://home.dev.account.gov.uk/security
       dynatraceRumUrl: ""
       accountDataApiUrl: https://stubs.manage.dev.account.gov.uk/account-data-api
+      notifySendEmailStubUrl: https://stubs.manage.dev.account.gov.uk/notify/send-email
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "e85e22eb-ab14-4881-8334-5e51ac46b08f",
@@ -111,6 +112,7 @@ Mappings:
       securityUrl: https://home.build.account.gov.uk/security
       dynatraceRumUrl: ""
       accountDataApiUrl: https://stubs.manage.build.account.gov.uk/account-data-api
+      notifySendEmailStubUrl: https://stubs.manage.build.account.gov.uk/notify/send-email
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "e85e22eb-ab14-4881-8334-5e51ac46b08f",
@@ -146,6 +148,7 @@ Mappings:
       securityUrl: https://home.staging.account.gov.uk/security
       dynatraceRumUrl: TODO
       accountDataApiUrl: https://7xgl7lexy4.execute-api.eu-west-2.amazonaws.com/staging
+      notifySendEmailStubUrl: ""
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "e85e22eb-ab14-4881-8334-5e51ac46b08f",
@@ -181,6 +184,7 @@ Mappings:
       securityUrl: https://home.integration.account.gov.uk/security
       dynatraceRumUrl: TODO
       accountDataApiUrl: https://hoidt6wujb.execute-api.eu-west-2.amazonaws.com/integration
+      notifySendEmailStubUrl: ""
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "a37858f1-45e5-4b9f-8d93-efbbc955ffbf",
@@ -216,6 +220,7 @@ Mappings:
       securityUrl: https://home.account.gov.uk/security
       dynatraceRumUrl: TODO
       accountDataApiUrl: https://0218o1p9tj.execute-api.eu-west-2.amazonaws.com/production
+      notifySendEmailStubUrl: ""
       notifyTemplateIds: |
         {
           "CREATE_PASSKEY_WITH_PASSKEY_NAME": "a37858f1-45e5-4b9f-8d93-efbbc955ffbf",
@@ -997,6 +1002,12 @@ Resources:
               EnvironmentConfiguration,
               !Ref Environment,
               notifyTemplateIds,
+            ]
+          NOTIFY_SEND_EMAIL_STUB_URL:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              notifySendEmailStubUrl,
             ]
       DeploymentPreference:
         Alarms: !If

--- a/solutions/commons/utils/constants.ts
+++ b/solutions/commons/utils/constants.ts
@@ -1,5 +1,7 @@
 import * as v from "valibot";
 
+export const mockEmailAddress = "testuser@test.null.local";
+
 export const fiveMinutesInSeconds = 300;
 export const oneDayInSeconds = 86400;
 export const oneYearInSeconds = 31536000;

--- a/solutions/commons/utils/notifications/index.ts
+++ b/solutions/commons/utils/notifications/index.ts
@@ -7,6 +7,12 @@ export enum NotificationType {
   CREATE_PASSKEY_WITHOUT_PASSKEY_NAME = "CREATE_PASSKEY_WITHOUT_PASSKEY_NAME",
 }
 
+export const notifyTemplateIDsSchema = v.pipe(
+  v.string(),
+  v.parseJson(),
+  v.record(v.enum(NotificationType), v.string()),
+);
+
 export const messageSchema = v.variant("notificationType", [
   v.pipe(
     v.object({

--- a/solutions/core/src/lambda/notifications-service.test.ts
+++ b/solutions/core/src/lambda/notifications-service.test.ts
@@ -467,6 +467,7 @@ describe("notifications-service", () => {
 
     expect(mockNotifyClientConstructor).toHaveBeenCalledWith(
       "http://localhost:6003/notify/send-email",
+      "test-api-key",
     );
 
     delete process.env["NOTIFY_SEND_EMAIL_STUB_URL"];

--- a/solutions/core/src/lambda/notifications-service.test.ts
+++ b/solutions/core/src/lambda/notifications-service.test.ts
@@ -446,9 +446,8 @@ describe("notifications-service", () => {
     );
   });
 
-  it("uses stub URL when email matches mockEmailAddress and NOTIFY_SEND_EMAIL_STUB_URL is set", async () => {
-    process.env["NOTIFY_SEND_EMAIL_STUB_URL"] =
-      "http://localhost:6003/notify/send-email";
+  it("uses stub URL when email matches mockEmailAddress and NOTIFY_STUB_URL is set", async () => {
+    process.env["NOTIFY_STUB_URL"] = "http://localhost:6003";
 
     const { handler } = await import("./notifications-service.js");
 
@@ -466,16 +465,15 @@ describe("notifications-service", () => {
     await handler(event);
 
     expect(mockNotifyClientConstructor).toHaveBeenCalledWith(
-      "http://localhost:6003/notify/send-email",
+      "http://localhost:6003",
       "test-api-key",
     );
 
-    delete process.env["NOTIFY_SEND_EMAIL_STUB_URL"];
+    delete process.env["NOTIFY_STUB_URL"];
   });
 
   it("uses API key when email does not match mockEmailAddress", async () => {
-    process.env["NOTIFY_SEND_EMAIL_STUB_URL"] =
-      "http://localhost:6003/notify/send-email";
+    process.env["NOTIFY_STUB_URL"] = "http://localhost:6003";
 
     const { handler } = await import("./notifications-service.js");
 
@@ -494,11 +492,11 @@ describe("notifications-service", () => {
 
     expect(mockNotifyClientConstructor).toHaveBeenCalledWith("test-api-key");
 
-    delete process.env["NOTIFY_SEND_EMAIL_STUB_URL"];
+    delete process.env["NOTIFY_STUB_URL"];
   });
 
-  it("uses API key when NOTIFY_SEND_EMAIL_STUB_URL is not set", async () => {
-    delete process.env["NOTIFY_SEND_EMAIL_STUB_URL"];
+  it("uses API key when NOTIFY_STUB_URL is not set", async () => {
+    delete process.env["NOTIFY_STUB_URL"];
 
     const { handler } = await import("./notifications-service.js");
 

--- a/solutions/core/src/lambda/notifications-service.test.ts
+++ b/solutions/core/src/lambda/notifications-service.test.ts
@@ -117,6 +117,11 @@ vi.mock(import("../../../commons/utils/metrics/index.js"), () => ({
 vi.mock(import("../../../commons/utils/notifications/index.js"), () => ({
   messageSchema: mockMessageSchema,
   NotificationType: MockNotificationType,
+  notifyTemplateIDsSchema: v.pipe(
+    v.string(),
+    v.parseJson(),
+    v.record(v.enum(MockNotificationType), v.string()),
+  ),
   sendNotification: vi.fn(),
 }));
 

--- a/solutions/core/src/lambda/notifications-service.test.ts
+++ b/solutions/core/src/lambda/notifications-service.test.ts
@@ -383,28 +383,6 @@ describe("notifications-service", () => {
     expect(mockSendEmail).not.toHaveBeenCalledWith();
   });
 
-  it("adds to batch failures for invalid result format", async () => {
-    const { handler } = await import("./notifications-service.js");
-
-    mockSendEmail.mockResolvedValue({ invalid: "response" });
-
-    const message = {
-      emailAddress: "test@example.com",
-      notificationType: "WITH_PERSONALISATION",
-      name: "Test User",
-    };
-
-    const event = createSQSEvent([createSQSRecord(JSON.stringify(message))]);
-    const result = await handler(event);
-
-    expect(result.batchItemFailures).toHaveLength(1);
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      "invalid_result_format",
-      expect.any(Object),
-    );
-    expect(mockSendEmail).not.toHaveBeenCalledWith();
-  });
-
   it("processes multiple records and returns partial failures", async () => {
     const { handler } = await import("./notifications-service.js");
 

--- a/solutions/core/src/lambda/notifications-service.test.ts
+++ b/solutions/core/src/lambda/notifications-service.test.ts
@@ -4,6 +4,7 @@ import * as v from "valibot";
 
 const mockGetSecret = vi.fn();
 const mockSendEmail = vi.fn();
+const mockNotifyClientConstructor = vi.fn();
 const mockLogger = {
   info: vi.fn(),
   error: vi.fn(),
@@ -90,8 +91,16 @@ vi.mock(import("@aws-lambda-powertools/parameters/secrets"), () => ({
 // @ts-expect-error
 vi.mock(import("notifications-node-client"), () => ({
   NotifyClient: class {
+    constructor(...args: unknown[]) {
+      mockNotifyClientConstructor(...args);
+    }
     sendEmail = mockSendEmail;
   },
+}));
+
+// @ts-expect-error
+vi.mock(import("../../../commons/utils/constants.js"), () => ({
+  mockEmailAddress: "testuser@test.null.local",
 }));
 
 // @ts-expect-error
@@ -435,6 +444,77 @@ describe("notifications-service", () => {
         reference: "ref-1",
       }),
     );
+  });
+
+  it("uses stub URL when email matches mockEmailAddress and NOTIFY_SEND_EMAIL_STUB_URL is set", async () => {
+    process.env["NOTIFY_SEND_EMAIL_STUB_URL"] =
+      "http://localhost:6003/notify/send-email";
+
+    const { handler } = await import("./notifications-service.js");
+
+    mockSendEmail.mockResolvedValue({
+      data: { id: "notify-id", reference: "ref" },
+    });
+
+    const message = {
+      emailAddress: "testuser@test.null.local",
+      notificationType: "WITH_PERSONALISATION",
+      name: "Test User",
+    };
+
+    const event = createSQSEvent([createSQSRecord(JSON.stringify(message))]);
+    await handler(event);
+
+    expect(mockNotifyClientConstructor).toHaveBeenCalledWith(
+      "http://localhost:6003/notify/send-email",
+    );
+
+    delete process.env["NOTIFY_SEND_EMAIL_STUB_URL"];
+  });
+
+  it("uses API key when email does not match mockEmailAddress", async () => {
+    process.env["NOTIFY_SEND_EMAIL_STUB_URL"] =
+      "http://localhost:6003/notify/send-email";
+
+    const { handler } = await import("./notifications-service.js");
+
+    mockSendEmail.mockResolvedValue({
+      data: { id: "notify-id", reference: "ref" },
+    });
+
+    const message = {
+      emailAddress: "other@example.com",
+      notificationType: "WITH_PERSONALISATION",
+      name: "Test User",
+    };
+
+    const event = createSQSEvent([createSQSRecord(JSON.stringify(message))]);
+    await handler(event);
+
+    expect(mockNotifyClientConstructor).toHaveBeenCalledWith("test-api-key");
+
+    delete process.env["NOTIFY_SEND_EMAIL_STUB_URL"];
+  });
+
+  it("uses API key when NOTIFY_SEND_EMAIL_STUB_URL is not set", async () => {
+    delete process.env["NOTIFY_SEND_EMAIL_STUB_URL"];
+
+    const { handler } = await import("./notifications-service.js");
+
+    mockSendEmail.mockResolvedValue({
+      data: { id: "notify-id", reference: "ref" },
+    });
+
+    const message = {
+      emailAddress: "testuser@test.null.local",
+      notificationType: "WITH_PERSONALISATION",
+      name: "Test User",
+    };
+
+    const event = createSQSEvent([createSQSRecord(JSON.stringify(message))]);
+    await handler(event);
+
+    expect(mockNotifyClientConstructor).toHaveBeenCalledWith("test-api-key");
   });
 
   it("calls metrics and logger cleanup methods", async () => {

--- a/solutions/core/src/lambda/notifications-service.ts
+++ b/solutions/core/src/lambda/notifications-service.ts
@@ -146,12 +146,19 @@ const processNotification = async (
 
     let sendResult: unknown;
     try {
-      const notifyClient = new NotifyClient(
+      let notifyClient: InstanceType<typeof NotifyClient>;
+
+      if (
         message.emailAddress === mockEmailAddress &&
-          process.env["NOTIFY_SEND_EMAIL_STUB_URL"]
-          ? process.env["NOTIFY_SEND_EMAIL_STUB_URL"]
-          : notifyApiKey,
-      );
+        process.env["NOTIFY_SEND_EMAIL_STUB_URL"]
+      ) {
+        notifyClient = new NotifyClient(
+          process.env["NOTIFY_SEND_EMAIL_STUB_URL"],
+          notifyApiKey,
+        );
+      } else {
+        notifyClient = new NotifyClient(notifyApiKey);
+      }
 
       sendResult = await notifyClient.sendEmail(
         templateId,

--- a/solutions/core/src/lambda/notifications-service.ts
+++ b/solutions/core/src/lambda/notifications-service.ts
@@ -14,9 +14,10 @@ import { metrics } from "../../../commons/utils/metrics/index.js";
 // notifications-node-client uses axios under the hood so we have to rely on it here
 // eslint-disable-next-line depend/ban-dependencies
 import { isAxiosError } from "axios";
+import type { NotificationType } from "../../../commons/utils/notifications/index.js";
 import {
   messageSchema,
-  NotificationType,
+  notifyTemplateIDsSchema,
 } from "../../../commons/utils/notifications/index.js";
 import { mockEmailAddress } from "../../../commons/utils/constants.js";
 
@@ -77,12 +78,6 @@ if (
     }),
   );
 }
-
-const notifyTemplateIDsSchema = v.pipe(
-  v.string(),
-  v.parseJson(),
-  v.record(v.enum(NotificationType), v.string()),
-);
 
 const templateIds = v.safeParse(
   notifyTemplateIDsSchema,

--- a/solutions/core/src/lambda/notifications-service.ts
+++ b/solutions/core/src/lambda/notifications-service.ts
@@ -144,7 +144,9 @@ const processNotification = async (
       return;
     }
 
-    let sendResult: unknown;
+    let sendResult: Awaited<
+      ReturnType<InstanceType<typeof NotifyClient>["sendEmail"]>
+    >;
     try {
       let notifyClient: InstanceType<typeof NotifyClient>;
 
@@ -197,30 +199,10 @@ const processNotification = async (
       return;
     }
 
-    const notifySuccessSchema = v.object({
-      data: v.object({
-        id: v.string(),
-        reference: v.nullish(v.string()),
-      }),
-    });
-
-    console.log("MHTEST_sendResult", sendResult);
-
-    const resultParsed = v.safeParse(notifySuccessSchema, sendResult);
-    if (!resultParsed.success) {
-      const errorName = "invalid_result_format";
-      logger.error(errorName, {
-        messageId: record.messageId,
-      });
-      addSendNotificationFailedMetric(errorName);
-      batchItemFailures.push({ itemIdentifier: record.messageId });
-      return;
-    }
-
     logger.info("notification_sent", {
       messageId: record.messageId,
-      id: resultParsed.output.data.id,
-      reference: resultParsed.output.data.reference,
+      id: sendResult.data.id,
+      reference: sendResult.data.reference,
     });
     metrics.addMetric("SendNotificationSucceeded", MetricUnit.Count, 1);
   } catch (error) {

--- a/solutions/core/src/lambda/notifications-service.ts
+++ b/solutions/core/src/lambda/notifications-service.ts
@@ -18,18 +18,9 @@ import {
   messageSchema,
   NotificationType,
 } from "../../../commons/utils/notifications/index.js";
+import { mockEmailAddress } from "../../../commons/utils/constants.js";
 
 type Personalisation = Record<string, string>;
-interface NotifyClientType {
-  sendEmail: (
-    templateId: string,
-    emailAddress: string,
-    options: {
-      personalisation: Personalisation;
-      reference: string;
-    },
-  ) => Promise<unknown>;
-}
 
 const addSendNotificationFailedMetric = (failureReason: string) => {
   metrics.addMetadata("SendNotificationFailedReason", failureReason);
@@ -86,8 +77,6 @@ if (
     }),
   );
 }
-
-const notifyClient: NotifyClientType = new NotifyClient(notifyApiKey);
 
 const notifyTemplateIDsSchema = v.pipe(
   v.string(),
@@ -157,6 +146,13 @@ const processNotification = async (
 
     let sendResult: unknown;
     try {
+      const notifyClient = new NotifyClient(
+        message.emailAddress === mockEmailAddress &&
+          process.env["NOTIFY_SEND_EMAIL_STUB_URL"]
+          ? process.env["NOTIFY_SEND_EMAIL_STUB_URL"]
+          : notifyApiKey,
+      );
+
       sendResult = await notifyClient.sendEmail(
         templateId,
         message.emailAddress,

--- a/solutions/core/src/lambda/notifications-service.ts
+++ b/solutions/core/src/lambda/notifications-service.ts
@@ -204,6 +204,8 @@ const processNotification = async (
       }),
     });
 
+    console.log("MHTEST_sendResult", sendResult);
+
     const resultParsed = v.safeParse(notifySuccessSchema, sendResult);
     if (!resultParsed.success) {
       const errorName = "invalid_result_format";

--- a/solutions/core/src/lambda/notifications-service.ts
+++ b/solutions/core/src/lambda/notifications-service.ts
@@ -150,10 +150,10 @@ const processNotification = async (
 
       if (
         message.emailAddress === mockEmailAddress &&
-        process.env["NOTIFY_SEND_EMAIL_STUB_URL"]
+        process.env["NOTIFY_STUB_URL"]
       ) {
         notifyClient = new NotifyClient(
-          process.env["NOTIFY_SEND_EMAIL_STUB_URL"],
+          process.env["NOTIFY_STUB_URL"],
           notifyApiKey,
         );
       } else {

--- a/solutions/stubs/src/generateRequestObject/handlers/create.njk
+++ b/solutions/stubs/src/generateRequestObject/handlers/create.njk
@@ -97,7 +97,7 @@
             <fieldset>
                 <legend>User email address (optional)</legend>
                 <input type="email" name="user_email_address" aria-label="User email address (optional)"/>
-                {% if emailsCanBeSent %}
+                {% if not isLocal %}
                     <i>Defaults to {{mockEmailAddress}} which will be sent to the Notify stub, not the real Notify service</i>                
                 {% else %}
                     <i>Emails are not sent when running locally</i>

--- a/solutions/stubs/src/generateRequestObject/handlers/create.njk
+++ b/solutions/stubs/src/generateRequestObject/handlers/create.njk
@@ -97,7 +97,11 @@
             <fieldset>
                 <legend>User email address (optional)</legend>
                 <input type="email" name="user_email_address" aria-label="User email address (optional)"/>
-                <i>Defaults to {{mockEmailAddress}} which will be sent to the Notify stub, not the real Notify service</i>                
+                {% if emailsCanBeSent %}
+                    <i>Defaults to {{mockEmailAddress}} which will be sent to the Notify stub, not the real Notify service</i>                
+                {% else %}
+                    <i>Emails are not sent when running locally</i>
+                {% endif %}
             </fieldset>
             <fieldset>
                 <legend>Account management API scenarios</legend>

--- a/solutions/stubs/src/generateRequestObject/handlers/create.njk
+++ b/solutions/stubs/src/generateRequestObject/handlers/create.njk
@@ -97,6 +97,7 @@
             <fieldset>
                 <legend>User email address (optional)</legend>
                 <input type="email" name="user_email_address" aria-label="User email address (optional)"/>
+                <i>Defaults to {{mockEmailAddress}} which will be sent to the Notify stub, not the real Notify service</i>                
             </fieldset>
             <fieldset>
                 <legend>Account management API scenarios</legend>

--- a/solutions/stubs/src/generateRequestObject/handlers/create.ts
+++ b/solutions/stubs/src/generateRequestObject/handlers/create.ts
@@ -18,7 +18,10 @@ import * as v from "valibot";
 import type { JWTPayload } from "jose";
 import { getEnvironment } from "../../../../commons/utils/getEnvironment/index.js";
 import { createHash } from "node:crypto";
-import { checkUserAgentCookieName } from "../../../../commons/utils/constants.js";
+import {
+  checkUserAgentCookieName,
+  mockEmailAddress,
+} from "../../../../commons/utils/constants.js";
 
 export const requestBodySchema = v.object({
   client_id: v.string(),
@@ -67,6 +70,7 @@ export async function createRequestObjectGet(
     jwtPayload,
     jwtHeader,
     originalRequestBody,
+    mockEmailAddress,
   });
   return reply;
 }

--- a/solutions/stubs/src/generateRequestObject/handlers/create.ts
+++ b/solutions/stubs/src/generateRequestObject/handlers/create.ts
@@ -71,7 +71,7 @@ export async function createRequestObjectGet(
     jwtHeader,
     originalRequestBody,
     mockEmailAddress,
-    emailsCanBeSent: getEnvironment() !== "local",
+    isLocal: getEnvironment() === "local",
   });
   return reply;
 }

--- a/solutions/stubs/src/generateRequestObject/handlers/create.ts
+++ b/solutions/stubs/src/generateRequestObject/handlers/create.ts
@@ -71,6 +71,7 @@ export async function createRequestObjectGet(
     jwtHeader,
     originalRequestBody,
     mockEmailAddress,
+    emailsCanBeSent: getEnvironment() !== "local",
   });
   return reply;
 }

--- a/solutions/stubs/src/index.ts
+++ b/solutions/stubs/src/index.ts
@@ -18,6 +18,7 @@ import { FastifyPowertoolsLogger } from "../../commons/utils/fastify/powertoolsL
 import { getEnvironment } from "../../commons/utils/getEnvironment/index.js";
 import { accountManagementApi } from "./accountManagementApi/index.js";
 import { accountDataApi } from "./accountDataApi/index.js";
+import { notify } from "./notify/index.js";
 
 export const initStubs = async function () {
   const fastify = Fastify.default({
@@ -114,6 +115,7 @@ export const initStubs = async function () {
   fastify.register(clientCallback);
   fastify.register(accountManagementApi);
   fastify.register(accountDataApi);
+  fastify.register(notify);
 
   return fastify;
 };

--- a/solutions/stubs/src/notify/handlers/sendEmail.test.ts
+++ b/solutions/stubs/src/notify/handlers/sendEmail.test.ts
@@ -1,24 +1,42 @@
 import type { FastifyReply, FastifyRequest } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { sendEmailPostHandler } from "./sendEmail.js";
 
 vi.mock(import("../../../../commons/utils/logger/index.js"));
+
+const mockTemplateIds = {
+  CREATE_PASSKEY_WITH_PASSKEY_NAME: "template-id-1",
+  CREATE_PASSKEY_WITHOUT_PASSKEY_NAME: "template-id-2",
+};
 
 describe("sendEmailPostHandler", () => {
   let mockRequest: Partial<FastifyRequest>;
   let mockReply: Partial<FastifyReply>;
+  let sendEmailPostHandler: (
+    request: FastifyRequest,
+    reply: FastifyReply,
+  ) => Promise<FastifyReply>;
+  let logger: Awaited<
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    typeof import("../../../../commons/utils/logger/index.js")
+  >["logger"];
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
+
+    process.env["NOTIFY_TEMPLATE_IDS"] = JSON.stringify(mockTemplateIds);
 
     mockReply = {
       send: vi.fn().mockReturnThis(),
     };
+
+    ({ sendEmailPostHandler } = await import("./sendEmail.js"));
+    ({ logger } = await import("../../../../commons/utils/logger/index.js"));
   });
 
   it("should return id and reference when reference is provided", async () => {
     mockRequest = {
-      body: { template_id: "test-template-id", reference: "test-reference" },
+      body: { template_id: "template-id-1", reference: "test-reference" },
     };
 
     await sendEmailPostHandler(
@@ -26,6 +44,11 @@ describe("sendEmailPostHandler", () => {
       mockReply as FastifyReply,
     );
 
+    expect(logger.info).toHaveBeenCalledWith("NotifySendEmailCalled", {
+      reference: "test-reference",
+      templateId: "template-id-1",
+      template: "CREATE_PASSKEY_WITH_PASSKEY_NAME",
+    });
     expect(mockReply.send).toHaveBeenCalledWith({
       data: {
         id: expect.any(String),
@@ -35,18 +58,38 @@ describe("sendEmailPostHandler", () => {
   });
 
   it("should return id and undefined reference when reference is not provided", async () => {
-    mockRequest = { body: { template_id: "test-template-id" } };
+    mockRequest = { body: { template_id: "template-id-2" } };
 
     await sendEmailPostHandler(
       mockRequest as FastifyRequest,
       mockReply as FastifyReply,
     );
 
+    expect(logger.info).toHaveBeenCalledWith("NotifySendEmailCalled", {
+      reference: undefined,
+      templateId: "template-id-2",
+      template: "CREATE_PASSKEY_WITHOUT_PASSKEY_NAME",
+    });
     expect(mockReply.send).toHaveBeenCalledWith({
       data: {
         id: expect.any(String),
         reference: undefined,
       },
+    });
+  });
+
+  it("should log undefined template when template_id is not recognised", async () => {
+    mockRequest = { body: { template_id: "unknown-template-id" } };
+
+    await sendEmailPostHandler(
+      mockRequest as FastifyRequest,
+      mockReply as FastifyReply,
+    );
+
+    expect(logger.info).toHaveBeenCalledWith("NotifySendEmailCalled", {
+      reference: undefined,
+      templateId: "unknown-template-id",
+      template: undefined,
     });
   });
 

--- a/solutions/stubs/src/notify/handlers/sendEmail.test.ts
+++ b/solutions/stubs/src/notify/handlers/sendEmail.test.ts
@@ -17,7 +17,9 @@ describe("sendEmailPostHandler", () => {
   });
 
   it("should return id and reference when reference is provided", async () => {
-    mockRequest = { body: { reference: "test-reference" } };
+    mockRequest = {
+      body: { template_id: "test-template-id", reference: "test-reference" },
+    };
 
     await sendEmailPostHandler(
       mockRequest as FastifyRequest,
@@ -33,7 +35,7 @@ describe("sendEmailPostHandler", () => {
   });
 
   it("should return id and undefined reference when reference is not provided", async () => {
-    mockRequest = { body: {} };
+    mockRequest = { body: { template_id: "test-template-id" } };
 
     await sendEmailPostHandler(
       mockRequest as FastifyRequest,
@@ -49,7 +51,7 @@ describe("sendEmailPostHandler", () => {
   });
 
   it("should throw when body is invalid", async () => {
-    mockRequest = { body: { reference: 123 } };
+    mockRequest = { body: { template_id: 123 } };
 
     await expect(
       sendEmailPostHandler(

--- a/solutions/stubs/src/notify/handlers/sendEmail.test.ts
+++ b/solutions/stubs/src/notify/handlers/sendEmail.test.ts
@@ -1,0 +1,61 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { sendEmailPostHandler } from "./sendEmail.js";
+
+vi.mock(import("../../../../commons/utils/logger/index.js"));
+
+describe("sendEmailPostHandler", () => {
+  let mockRequest: Partial<FastifyRequest>;
+  let mockReply: Partial<FastifyReply>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockReply = {
+      send: vi.fn().mockReturnThis(),
+    };
+  });
+
+  it("should return id and reference when reference is provided", async () => {
+    mockRequest = { body: { reference: "test-reference" } };
+
+    await sendEmailPostHandler(
+      mockRequest as FastifyRequest,
+      mockReply as FastifyReply,
+    );
+
+    expect(mockReply.send).toHaveBeenCalledWith({
+      data: {
+        id: expect.any(String),
+        reference: "test-reference",
+      },
+    });
+  });
+
+  it("should return id and undefined reference when reference is not provided", async () => {
+    mockRequest = { body: {} };
+
+    await sendEmailPostHandler(
+      mockRequest as FastifyRequest,
+      mockReply as FastifyReply,
+    );
+
+    expect(mockReply.send).toHaveBeenCalledWith({
+      data: {
+        id: expect.any(String),
+        reference: undefined,
+      },
+    });
+  });
+
+  it("should throw when body is invalid", async () => {
+    mockRequest = { body: { reference: 123 } };
+
+    await expect(
+      sendEmailPostHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/solutions/stubs/src/notify/handlers/sendEmail.ts
+++ b/solutions/stubs/src/notify/handlers/sendEmail.ts
@@ -2,6 +2,12 @@ import type { FastifyRequest, FastifyReply } from "fastify";
 import { randomUUID } from "node:crypto";
 import * as v from "valibot";
 import { logger } from "../../../../commons/utils/logger/index.js";
+import { notifyTemplateIDsSchema } from "../../../../commons/utils/notifications/index.js";
+
+const templateIds = v.safeParse(
+  notifyTemplateIDsSchema,
+  process.env["NOTIFY_TEMPLATE_IDS"],
+);
 
 export async function sendEmailPostHandler(
   request: FastifyRequest,
@@ -9,6 +15,7 @@ export async function sendEmailPostHandler(
 ) {
   const body = v.parse(
     v.object({
+      template_id: v.string(),
       reference: v.optional(v.string()),
     }),
     request.body,
@@ -17,6 +24,9 @@ export async function sendEmailPostHandler(
 
   logger.info("NotifySendEmailCalled", {
     reference: body.reference,
+    templateId: body.template_id,
+    // @ts-expect-error
+    template: templateIds[body.template_id],
   });
 
   await reply.send({

--- a/solutions/stubs/src/notify/handlers/sendEmail.ts
+++ b/solutions/stubs/src/notify/handlers/sendEmail.ts
@@ -1,0 +1,29 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import { randomUUID } from "node:crypto";
+import * as v from "valibot";
+import { logger } from "../../../../commons/utils/logger/index.js";
+
+export async function sendEmailPostHandler(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  const body = v.parse(
+    v.object({
+      reference: v.optional(v.string()),
+    }),
+    request.body,
+    { abortEarly: false },
+  );
+
+  logger.info("NotifySendEmailCalled", {
+    reference: body.reference,
+  });
+
+  await reply.send({
+    data: {
+      id: randomUUID(),
+      reference: body.reference,
+    },
+  });
+  return await reply;
+}

--- a/solutions/stubs/src/notify/handlers/sendEmail.ts
+++ b/solutions/stubs/src/notify/handlers/sendEmail.ts
@@ -4,7 +4,7 @@ import * as v from "valibot";
 import { logger } from "../../../../commons/utils/logger/index.js";
 import { notifyTemplateIDsSchema } from "../../../../commons/utils/notifications/index.js";
 
-const templateIds = v.safeParse(
+const templateIds = v.parse(
   notifyTemplateIDsSchema,
   process.env["NOTIFY_TEMPLATE_IDS"],
 );
@@ -25,8 +25,9 @@ export async function sendEmailPostHandler(
   logger.info("NotifySendEmailCalled", {
     reference: body.reference,
     templateId: body.template_id,
-    // @ts-expect-error
-    template: templateIds[body.template_id],
+    template: Object.entries(templateIds).find(
+      ([, id]) => id === body.template_id,
+    )?.[0],
   });
 
   await reply.send({

--- a/solutions/stubs/src/notify/index.test.ts
+++ b/solutions/stubs/src/notify/index.test.ts
@@ -6,7 +6,7 @@ import { notify } from "./index.js";
 vi.mock(import("../utils/paths.js"), () => ({
   paths: {
     notify: {
-      sendEmail: "/notify/send-email",
+      sendEmail: "/notify/v2/notifications/email",
     },
   },
 }));
@@ -29,7 +29,7 @@ describe("notify", () => {
 
     expect(mockApp.post).toHaveBeenCalledTimes(1);
     expect(mockApp.post).toHaveBeenCalledWith(
-      "/notify/send-email",
+      "/notify/v2/notifications/email",
       expect.any(Function),
     );
   });

--- a/solutions/stubs/src/notify/index.test.ts
+++ b/solutions/stubs/src/notify/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { notify } from "./index.js";
+
+// @ts-expect-error
+vi.mock(import("../utils/paths.js"), () => ({
+  paths: {
+    notify: {
+      sendEmail: "/notify/send-email",
+    },
+  },
+}));
+
+vi.mock(import("./handlers/sendEmail.js"), () => ({
+  sendEmailPostHandler: vi.fn(),
+}));
+
+describe("notify", () => {
+  let mockApp: FastifyInstance;
+
+  beforeEach(() => {
+    mockApp = {
+      post: vi.fn(),
+    } as unknown as FastifyInstance;
+  });
+
+  it("should register the sendEmail POST route", () => {
+    notify(mockApp);
+
+    expect(mockApp.post).toHaveBeenCalledTimes(1);
+    expect(mockApp.post).toHaveBeenCalledWith(
+      "/notify/send-email",
+      expect.any(Function),
+    );
+  });
+
+  it("should call sendEmailPostHandler when POST route is invoked", async () => {
+    const { sendEmailPostHandler } = await import("./handlers/sendEmail.js");
+    notify(mockApp);
+
+    const registeredHandler = vi.mocked(mockApp.post).mock
+      .calls[0]![1] as unknown as (...args: any) => any;
+    const mockRequest = {};
+    const mockReply = {};
+
+    await registeredHandler(mockRequest, mockReply);
+
+    expect(sendEmailPostHandler).toHaveBeenCalledWith(mockRequest, mockReply);
+  });
+});

--- a/solutions/stubs/src/notify/index.test.ts
+++ b/solutions/stubs/src/notify/index.test.ts
@@ -6,7 +6,7 @@ import { notify } from "./index.js";
 vi.mock(import("../utils/paths.js"), () => ({
   paths: {
     notify: {
-      sendEmail: "/notify/*",
+      sendEmail: "/v2/notifications/email",
     },
   },
 }));
@@ -29,7 +29,7 @@ describe("notify", () => {
 
     expect(mockApp.post).toHaveBeenCalledTimes(1);
     expect(mockApp.post).toHaveBeenCalledWith(
-      "/notify/*",
+      "/v2/notifications/email",
       expect.any(Function),
     );
   });

--- a/solutions/stubs/src/notify/index.test.ts
+++ b/solutions/stubs/src/notify/index.test.ts
@@ -6,7 +6,7 @@ import { notify } from "./index.js";
 vi.mock(import("../utils/paths.js"), () => ({
   paths: {
     notify: {
-      sendEmail: "/notify/v2/notifications/email",
+      sendEmail: "/notify/*",
     },
   },
 }));
@@ -29,7 +29,7 @@ describe("notify", () => {
 
     expect(mockApp.post).toHaveBeenCalledTimes(1);
     expect(mockApp.post).toHaveBeenCalledWith(
-      "/notify/v2/notifications/email",
+      "/notify/*",
       expect.any(Function),
     );
   });

--- a/solutions/stubs/src/notify/index.ts
+++ b/solutions/stubs/src/notify/index.ts
@@ -1,0 +1,11 @@
+import type { FastifyInstance } from "fastify";
+import { paths } from "../utils/paths.js";
+
+export const notify = function (fastify: FastifyInstance) {
+  fastify.post(paths.notify.sendEmail, async function (request, reply) {
+    return (await import("./handlers/sendEmail.js")).sendEmailPostHandler(
+      request,
+      reply,
+    );
+  });
+};

--- a/solutions/stubs/src/types/common.ts
+++ b/solutions/stubs/src/types/common.ts
@@ -1,3 +1,5 @@
+import { mockEmailAddress } from "../../../commons/utils/constants.js";
+
 export enum HttpCodesEnum {
   BAD_REQUEST = 400,
 }
@@ -92,7 +94,7 @@ export const getUsers = (user: string): User => {
     return {
       sub: "urn:fdc:gov.uk:default",
       public_sub: "4c950955-03c3-45a4-a97e-763152c172ff",
-      email: "testuser@test.null.local",
+      email: mockEmailAddress,
     };
   }
 };

--- a/solutions/stubs/src/utils/paths.ts
+++ b/solutions/stubs/src/utils/paths.ts
@@ -18,6 +18,6 @@ export const paths = {
       "/account-data-api/accounts/:publicSubjectId/authenticators/passkeys",
   },
   notify: {
-    sendEmail: "/notify/send-email",
+    sendEmail: "/notify/v2/notifications/email",
   },
 } as const;

--- a/solutions/stubs/src/utils/paths.ts
+++ b/solutions/stubs/src/utils/paths.ts
@@ -18,6 +18,6 @@ export const paths = {
       "/account-data-api/accounts/:publicSubjectId/authenticators/passkeys",
   },
   notify: {
-    sendEmail: "/notify/*",
+    sendEmail: "/v2/notifications/email",
   },
 } as const;

--- a/solutions/stubs/src/utils/paths.ts
+++ b/solutions/stubs/src/utils/paths.ts
@@ -17,4 +17,7 @@ export const paths = {
     createPasskey:
       "/account-data-api/accounts/:publicSubjectId/authenticators/passkeys",
   },
+  notify: {
+    sendEmail: "/notify/send-email",
+  },
 } as const;

--- a/solutions/stubs/src/utils/paths.ts
+++ b/solutions/stubs/src/utils/paths.ts
@@ -18,6 +18,6 @@ export const paths = {
       "/account-data-api/accounts/:publicSubjectId/authenticators/passkeys",
   },
   notify: {
-    sendEmail: "/notify/v2/notifications/email",
+    sendEmail: "/notify/*",
   },
 } as const;


### PR DESCRIPTION
In environments where the stubs are running (dev and build) the Notify endpoint for sending emails is stubbed when the email address to which the email is being sent is `testuser@test.null.local` (which is the default). The stub logs the reference and template details from the request body.

This allows us not to spam Notify when running performance tests.

If the email address is anything else then the request won't be made to the stub but will actually be made to Notify as is currently the case.

Also removes hard-coded types from the notifications handler lambda as the Notify client library now ships with TypeScript types.