### PR TITLE
BAU: simpler client IDs

### DIFF
--- a/solutions/config/build-config.json
+++ b/solutions/config/build-config.json
@@ -1,7 +1,7 @@
 {
   "client_registry": [
     {
-      "client_id": "044a1e577b3d4d24a2e596aeab474f20",
+      "client_id": "auth",
       "scope": "testing-journey account-delete passkey-create",
       "redirect_uris": [
         "https://stubs.manage.build.account.gov.uk/auth/callback"
@@ -11,7 +11,7 @@
       "consider_user_logged_in": false
     },
     {
-      "client_id": "4ed565b5673b420cb02096fe2cdbe639",
+      "client_id": "home",
       "scope": "testing-journey passkey-create",
       "redirect_uris": [
         "https://stubs.manage.build.account.gov.uk/home/callback"

--- a/solutions/config/dev-config.json
+++ b/solutions/config/dev-config.json
@@ -1,7 +1,7 @@
 {
   "client_registry": [
     {
-      "client_id": "d449cdc5a9ff4958a855a0ea636b04c3",
+      "client_id": "auth",
       "scope": "testing-journey account-delete passkey-create",
       "redirect_uris": [
         "https://stubs.manage.dev.account.gov.uk/auth/callback"
@@ -11,7 +11,7 @@
       "consider_user_logged_in": false
     },
     {
-      "client_id": "8d74d191ee39446fb20a39c1f20e48cc",
+      "client_id": "home",
       "scope": "testing-journey passkey-create",
       "redirect_uris": [
         "https://stubs.manage.dev.account.gov.uk/home/callback"

--- a/solutions/config/integration-config.json
+++ b/solutions/config/integration-config.json
@@ -1,7 +1,7 @@
 {
   "client_registry": [
     {
-      "client_id": "0b649817932e4632861f1ab3fccb650d",
+      "client_id": "auth",
       "scope": "account-delete passkey-create",
       "redirect_uris": [
         "https://signin.integration.account.gov.uk/create-passkey-callback"
@@ -11,7 +11,7 @@
       "consider_user_logged_in": false
     },
     {
-      "client_id": "cdf0311ea91648d4a25214415e521ef5",
+      "client_id": "home",
       "scope": "passkey-create",
       "redirect_uris": ["https://home.integration.account.gov.uk/amc/callback"],
       "client_name": "Home",

--- a/solutions/config/local-config.json
+++ b/solutions/config/local-config.json
@@ -1,7 +1,7 @@
 {
   "client_registry": [
     {
-      "client_id": "ef2b684f972a41f7915369979128ba5b",
+      "client_id": "auth",
       "scope": "testing-journey account-delete passkey-create",
       "redirect_uris": ["http://localhost:6003/auth/callback"],
       "client_name": "Auth",
@@ -10,7 +10,7 @@
       "consider_user_logged_in": false
     },
     {
-      "client_id": "537595decf204d96a3f9b6808c4122ce",
+      "client_id": "home",
       "scope": "testing-journey passkey-create",
       "redirect_uris": ["http://localhost:6003/home/callback"],
       "client_name": "Home",

--- a/solutions/config/production-config.json
+++ b/solutions/config/production-config.json
@@ -1,7 +1,7 @@
 {
   "client_registry": [
     {
-      "client_id": "be05e73e93e94626917b2bc0d7627cfa",
+      "client_id": "auth",
       "scope": "account-delete passkey-create",
       "redirect_uris": [
         "https://signin.account.gov.uk/create-passkey-callback"
@@ -11,7 +11,7 @@
       "consider_user_logged_in": false
     },
     {
-      "client_id": "261b31a23ea2408094b7f8480d486fad",
+      "client_id": "home",
       "scope": "passkey-create",
       "redirect_uris": ["https://home.account.gov.uk/amc/callback"],
       "client_name": "Home",

--- a/solutions/config/schema/config.json
+++ b/solutions/config/schema/config.json
@@ -81,7 +81,7 @@
         "client_id": {
           "description": "Unique client_id issued to an AMC client",
           "type": "string",
-          "pattern": "^[A-Fa-f0-9]{32}$"
+          "pattern": "^[A-Za-z0-9]+$"
         },
         "scope": {
           "description": "String containing a space-separated list of scope values that the client can use",

--- a/solutions/config/staging-config.json
+++ b/solutions/config/staging-config.json
@@ -1,7 +1,7 @@
 {
   "client_registry": [
     {
-      "client_id": "bb8ba862f42b4e5eb97cc0950f6419ca",
+      "client_id": "auth",
       "scope": "account-delete passkey-create",
       "redirect_uris": [
         "https://signin.staging.account.gov.uk/create-passkey-callback"
@@ -11,7 +11,7 @@
       "consider_user_logged_in": false
     },
     {
-      "client_id": "63385eefbc1649f9bc50eb9fd7c04de0",
+      "client_id": "home",
       "scope": "passkey-create",
       "redirect_uris": ["https://home.staging.account.gov.uk/amc/callback"],
       "client_name": "Home",


### PR DESCRIPTION
Simplify the client IDs across all environments so that it's clearer which client is which. This will make reading the CloudWatch dashboard easier. This has been communicated to auth who are updating their config where necessary.