### PR TITLE
OLH-3935: add unit test to deploy to main workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -97,6 +97,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build:all
 
+      - name: Test
+        run: npm run test
+
       - name: Deploy
         uses: govuk-one-login/devplatform-upload-action@5879c30205266ad61e8299a4fcea76364530c9c1
         with:

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -86,6 +86,16 @@
             "path": "jobs.deploy",
             "name": "Deploy"
           }
+        },
+        {
+          "check-types": ["unit", "new feature", "regression"],
+          "provider": "GitHub",
+          "phase": "pre-upload",
+          "config": {
+            "file": ".github/workflows/test.yaml",
+            "path": "jobs.test",
+            "name": "Test"
+          }
         }
       ]
     }


### PR DESCRIPTION
Unit tests must pass before deployment happens on merge to main.

Unit tests are already run pre-merge so they would also be expected to pass at this stage – this is just an additional measure to achieve "Bronze" status in the quality gates initiative. 