### PR TITLE
BAU: restrict pipeline Slack notifications to failures only

### DIFF
--- a/solutions/infra/pipelines.tf
+++ b/solutions/infra/pipelines.tf
@@ -22,7 +22,7 @@ resource "aws_cloudformation_stack" "amc_pipeline_stack" {
     IncludePromotion                        = contains(["build", "staging"], var.environment) ? "Yes" : "No"
     AllowedAccounts                         = join(",", var.allowed_promotion_accounts)
     BuildNotificationStackName              = "build-notifications"
-    SlackNotificationType                   = var.environment == "dev" ? "None" : "All"
+    SlackNotificationType                   = var.environment == "dev" ? "None" : "Failures"
     ProgrammaticPermissionsBoundary         = "True"
     AllowedServiceOne                       = "AppConfig"
     AllowedServiceTwo                       = "EC2" # Required to attach lambdas to VPC


### PR DESCRIPTION
Pipeline success notifications create noise in Slack channels. Only failure notifications are actionable, so restrict SlackNotificationType from "All" to "Failures" for non-dev environments.