### PR TITLE
BAU: update frontend lambda subnets

### DIFF
--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -2297,6 +2297,11 @@ Resources:
     Properties:
       CodeUri: solutions/frontend/dist
       Handler: lambda.handler
+    VpcConfig:
+      SubnetIds:
+        - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdA
+        - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
+        - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
       DeploymentPreference:
         Alarms:
           - !Ref FrontendLambdaErrorsAlarm


### PR DESCRIPTION
Updates the subnets for the frontend lambda so they can access the AMF JWKS which is at `https://home.{env}.account.gov.uk/.well-known/jwks.json`