### PR TITLE
BAU: add --ignore-scripts to npx playwright

### DIFF
--- a/solutions/integration-tests/run-tests.sh
+++ b/solutions/integration-tests/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "${1:-}" == "run-server" ]]; then
-  npx playwright run-server --port 3000 --host 0.0.0.0 &
+  npx --ignore-scripts playwright run-server --port 3000 --host 0.0.0.0 &
   python3 -m http.server 8000
 else
   npm run test


### PR DESCRIPTION
Resolves [SonarQube warning](https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&id=govuk-one-login_account-components&open=AZ3Uv9q56ptmxycimV8I) about potential execution of lifecycle scripts during npx package resolution in `run-tests.sh`.

## Testing

Verified locally that `npx --ignore-scripts playwright run-server` starts the Playwright server successfully — the flag only prevents install lifecycle scripts, not binary execution.
