### PR TITLE
OLH-4070: get passkey schema updates

### DIFF
--- a/solutions/frontend/src/utils/accountDataApiClient.ts
+++ b/solutions/frontend/src/utils/accountDataApiClient.ts
@@ -48,7 +48,7 @@ export class AccountDataApiClient extends JsonApiClient {
                   v.string(),
                   v.transform((input) => new Date(input)),
                 ),
-                lastUsedAt: v.optional(
+                lastUsedAt: v.nullish(
                   v.pipe(
                     v.string(),
                     v.transform((input) => new Date(input)),

--- a/solutions/frontend/src/utils/jsonApiClient.test.ts
+++ b/solutions/frontend/src/utils/jsonApiClient.test.ts
@@ -5,7 +5,6 @@ import type { APIGatewayProxyEvent } from "aws-lambda";
 
 const mockLogger = vi.hoisted(() => ({
   error: vi.fn(),
-  info: vi.fn(),
 }));
 
 const mockGetPropsFromAPIGatewayEvent = vi.hoisted(() => vi.fn());
@@ -320,7 +319,12 @@ describe("jsonApiClient", () => {
       });
 
       it("should return error when response body doesn't match schema", async () => {
-        const responseData = { id: "invalid", name: "test" };
+        const responseData = {
+          id: "invalid",
+          name: "test",
+          nested: {},
+          list: [1, 2, "3"],
+        };
         const response = {
           ok: true,
           json: vi.fn().mockResolvedValue(responseData),
@@ -328,6 +332,10 @@ describe("jsonApiClient", () => {
         const schema = v.object({
           id: v.number(),
           name: v.string(),
+          nested: v.object({
+            prop: v.string(),
+          }),
+          list: v.array(v.number()),
         });
         const errorMap = {};
 
@@ -341,6 +349,29 @@ describe("jsonApiClient", () => {
           success: false,
           error: "ErrorValidatingResponseBody",
           rawResponse: response,
+        });
+        expect(mockLogger.error).toHaveBeenCalledWith({
+          message: "ErrorValidatingResponseBody",
+          issues: [
+            {
+              kind: "schema",
+              type: "number",
+              expected: "number",
+              path: "id",
+            },
+            {
+              expected: '"prop"',
+              kind: "schema",
+              path: "nested.prop",
+              type: "object",
+            },
+            {
+              expected: "number",
+              kind: "schema",
+              path: "list.2",
+              type: "number",
+            },
+          ],
         });
       });
     });

--- a/solutions/frontend/src/utils/jsonApiClient.ts
+++ b/solutions/frontend/src/utils/jsonApiClient.ts
@@ -122,10 +122,16 @@ export abstract class JsonApiClient {
 
       const body = v.safeParse(successResponseBodySchema, responseJson);
       if (!body.success) {
-        logger.info("MHTEST");
-        logger.info("response status debug", { status: response.status });
-        logger.info("responseJson debug", {
-          responseJson: JSON.stringify(responseJson, null, 2),
+        logger.error({
+          message: "ErrorValidatingResponseBody",
+          issues: body.issues.map((issue) => ({
+            kind: issue.kind,
+            type: issue.type,
+            expected: issue.expected,
+            path: issue.path
+              ?.map((item) => ("key" in item ? item.key : undefined))
+              .join("."),
+          })),
         });
 
         return {


### PR DESCRIPTION
Update the get passkeys schema to allow the `lastUsedAt` field to be `null`.

Also adds better logging to the JSON API client to log details of issues when parsing of a response body against a schema fails.