### PR TITLE
OLH-4142: Fix Show password component on delete journey

### DIFF
--- a/solutions/frontend/src/journeys/account-delete/templates/enterPassword.njk
+++ b/solutions/frontend/src/journeys/account-delete/templates/enterPassword.njk
@@ -1,5 +1,5 @@
 {% extends "templates/layout/base-page.njk" %}
-{% from "govuk/components/password-input/macro.njk" import govukPasswordInput %}
+{% from "templates/common/password-input-macro.njk" import govukInputWithShowPassword %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'journey:enterPassword.pageTitle' | translate %}
@@ -8,17 +8,19 @@
   <form method="post">
     <input type="hidden" name="_csrf" value="{{ globals.csrfToken }}">
 
-    {{ govukPasswordInput({
-        label: {
-          text: 'journey:enterPassword.inputLabel' | translate,
-          classes: "govuk-label--l",
-          isPageHeading: true
-        },
-        name: "password",
-        errorMessage: {
-          text: errors.password.text
-        } if (errors.password)})
-    }}
+    {{ govukInputWithShowPassword({
+      label:{
+        text: 'journey:enterPassword.inputLabel' | translate,
+        classes: "govuk-label--l",
+        isPageHeading: true
+      },
+      id: "password",
+      errors: { 
+        password: { 
+          text: errors.password.text 
+        }
+      } if errors.password
+    }) }}
 
     {{ govukButton({
       text: 'journey:enterPassword.buttonLabel' | translate,

--- a/solutions/frontend/src/journeys/testing-journey/enterPassword.njk
+++ b/solutions/frontend/src/journeys/testing-journey/enterPassword.njk
@@ -11,7 +11,9 @@
     <input type="hidden" name="_csrf" value="{{ globals.csrfToken }}">
 
     {{ govukInputWithShowPassword({
-      label: 'journey:enterPassword.inputLabel' | translate,
+      label: {
+        text: 'journey:enterPassword.inputLabel' | translate
+      },
       id: "password"
     }) }}
 

--- a/solutions/frontend/src/templates/common/password-input-macro.njk
+++ b/solutions/frontend/src/templates/common/password-input-macro.njk
@@ -2,9 +2,7 @@
 
 {% macro govukInputWithShowPassword(settings) %}
     {{ govukPasswordInput({
-      label: {
-        text: settings.label
-      },
+      label: settings.label,
       name: settings.id,
       type: "password",
       spellcheck: false,


### PR DESCRIPTION
A bug was raised on AMF where the text for the Show/Hide password button was always displayed in English regardless of current language selection.

~This applies [the same fix from this pr](https://github.com/govuk-one-login/di-account-management-frontend/pull/2991) on AMC.~

The above was wrong ☝️ 

It turned out that on AMC there was a similar issue, not due to context not being passed into the nunjucks macro (as was the case on AMF), but as a result of using the uncustomised version of the show password component direct from the DS, and not passing in translation strings.
This updates the delete account journey to use the custom macro instead should fix the Welsh issue.

Not too sure why the `translate` function in AMC is "aware" of context within a macro, but the one in AMF is not, but it might be something to look into.