### PR TITLE
OLH-4172: analytics for all paths

### DIFF
--- a/solutions/frontend/src/index.ts
+++ b/solutions/frontend/src/index.ts
@@ -40,6 +40,7 @@ import { getEnvironment } from "../../commons/utils/getEnvironment/index.js";
 import { FastifyPowertoolsLogger } from "../../commons/utils/fastify/powertoolsLogger/index.js";
 import { resolveEnvVarToBool } from "../../commons/utils/resolveEnvVarToBool/index.js";
 import { unsuccessfulJourneyActionErrors } from "./journeys/utils/journeyActions.js";
+import { setAnalyticsForPath } from "./utils/setAnalyticsForPath/index.js";
 
 await configureI18n({
   [Lang.English]: {
@@ -96,6 +97,7 @@ export const initFrontend = async function () {
         request.cookies[channelCookieName] === "generic_app",
     };
   });
+  fastify.addHook("onRequest", setAnalyticsForPath);
   fastify.decorateReply("render", render);
 
   fastify.setNotFoundHandler(async function (request, reply) {

--- a/solutions/frontend/src/journeys/utils/onRequest.test.ts
+++ b/solutions/frontend/src/journeys/utils/onRequest.test.ts
@@ -21,22 +21,12 @@ vi.mock(import("../../utils/paths.js"), () => ({
       others: {
         completeFailedJourney: {
           path: "/complete-failed-journey",
-          analytics: {
-            taxonomyLevel1: "others",
-            taxonomyLevel2: "callback",
-            contentId: "callback-page",
-          },
         },
       },
       "test-scope": {
         "test-state": {
           page: {
             path: "/test-path",
-            analytics: {
-              taxonomyLevel1: "test",
-              taxonomyLevel2: "scope",
-              contentId: "test-page",
-            },
           },
         },
       },
@@ -290,29 +280,6 @@ describe("onRequest", () => {
       expect(mockReply.journeyStates).toStrictEqual({
         "test-scope": mockActor,
       });
-    });
-
-    it("should set analytics from path configuration for journey paths", async () => {
-      await onRequest(mockRequest as FastifyRequest, mockReply as FastifyReply);
-
-      expect(mockReply.analytics).toStrictEqual({
-        taxonomyLevel1: "test",
-        taxonomyLevel2: "scope",
-        contentId: "test-page",
-      });
-    });
-
-    it("should not set analytics when path has no analytics configuration", async () => {
-      // Test with a path that has no analytics in the mock
-      mockReply.globals = {
-        currentUrl: {
-          pathname: "/error",
-        } as URL,
-      };
-
-      await onRequest(mockRequest as FastifyRequest, mockReply as FastifyReply);
-
-      expect(mockReply.analytics).toBeUndefined();
     });
 
     it("should set buildCompleteFailedJourneyUri function on globals", async () => {

--- a/solutions/frontend/src/journeys/utils/onRequest.ts
+++ b/solutions/frontend/src/journeys/utils/onRequest.ts
@@ -167,16 +167,6 @@ export const onRequest = async (
     return await reply;
   }
 
-  if (pathObjectForCurrentState) {
-    // @ts-expect-error
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    reply.analytics = pathObjectForCurrentState.analytics;
-  } else if (otherJourneyPathObject) {
-    // @ts-expect-error
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    reply.analytics = otherJourneyPathObject.analytics;
-  }
-
   reply.journeyStates = {
     ...reply.journeyStates,
     [claims.scope]: actor,

--- a/solutions/frontend/src/utils/paths.ts
+++ b/solutions/frontend/src/utils/paths.ts
@@ -5,7 +5,7 @@ import { TestingJourneyState } from "../journeys/utils/stateMachines/testing-jou
 import { Scope } from "../../../commons/utils/commonTypes.js";
 import { analyticsDefaults } from "./constants.js";
 
-type PathsMap = Record<
+export type PathsMap = Record<
   string,
   { path: `/${string}`; analytics?: FastifyReply["analytics"] }
 >;

--- a/solutions/frontend/src/utils/setAnalyticsForPath/index.test.ts
+++ b/solutions/frontend/src/utils/setAnalyticsForPath/index.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { setAnalyticsForPath } from "./index.js";
+import type { FastifyRequest, FastifyReply } from "fastify";
+
+describe("setAnalyticsForPath", () => {
+  let reply: Partial<FastifyReply>;
+
+  beforeEach(() => {
+    reply = {};
+  });
+
+  it("should set analytics on reply when path has analytics defined", async () => {
+    const request = { url: "/set-up-passkey" };
+
+    await setAnalyticsForPath(request as FastifyRequest, reply as FastifyReply);
+
+    expect(reply.analytics).toStrictEqual({
+      taxonomyLevel1: "accounts",
+      taxonomyLevel2: "manage",
+      taxonomyLevel3: "passkey",
+    });
+  });
+
+  it("should not set analytics on reply when path has no analytics defined", async () => {
+    const request = { url: "/testing-journey/step-1" };
+
+    await setAnalyticsForPath(request as FastifyRequest, reply as FastifyReply);
+
+    expect(reply.analytics).toBeUndefined();
+  });
+
+  it("should not set analytics on reply when path does not match any known path", async () => {
+    const request = { url: "/unknown-path" };
+
+    await setAnalyticsForPath(request as FastifyRequest, reply as FastifyReply);
+
+    expect(reply.analytics).toBeUndefined();
+  });
+
+  it("should match path ignoring query parameters", async () => {
+    const request = { url: "/set-up-passkey?foo=bar" };
+
+    await setAnalyticsForPath(request as FastifyRequest, reply as FastifyReply);
+
+    expect(reply.analytics).toStrictEqual({
+      taxonomyLevel1: "accounts",
+      taxonomyLevel2: "manage",
+      taxonomyLevel3: "passkey",
+    });
+  });
+
+  it("should set analytics for paths defined in paths.others", async () => {
+    const request = { url: "/error" };
+
+    await setAnalyticsForPath(request as FastifyRequest, reply as FastifyReply);
+
+    expect(reply.analytics).toStrictEqual({
+      taxonomyLevel1: "accounts",
+      contentId: "a1a3dddd-9e65-40dc-9256-12ed597ec40e",
+    });
+  });
+});

--- a/solutions/frontend/src/utils/setAnalyticsForPath/index.ts
+++ b/solutions/frontend/src/utils/setAnalyticsForPath/index.ts
@@ -3,30 +3,28 @@ import type { PathsMap } from "../paths.js";
 import { paths } from "../paths.js";
 import { Scope } from "../../../../commons/utils/commonTypes.js";
 
+const findAnalytics = (pathsMap: PathsMap, pathname: string) =>
+  Object.values(pathsMap).find(
+    (path) => path.path === pathname && path.analytics,
+  )?.analytics;
+
 export const setAnalyticsForPath = async (
   request: FastifyRequest,
   reply: FastifyReply,
 ) => {
   const url = new URL(request.url, "http://localhost");
-  const scopes = Object.values(Scope);
 
-  for (const scope of scopes) {
-    const states = paths.journeys[scope];
+  const analytics = findAnalytics(paths.others, url.pathname);
+  if (analytics) {
+    reply.analytics = analytics;
+  }
 
-    for (const state of Object.values(states)) {
+  for (const scope of Object.values(Scope)) {
+    for (const state of Object.values(paths.journeys[scope])) {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      for (const path of Object.values(state as PathsMap)) {
-        if (path.path === url.pathname && path.analytics) {
-          reply.analytics = path.analytics;
-          return;
-        }
-      }
-    }
-
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    for (const path of Object.values(paths.others as PathsMap)) {
-      if (path.path === url.pathname && path.analytics) {
-        reply.analytics = path.analytics;
+      const analytics = findAnalytics(state as PathsMap, url.pathname);
+      if (analytics) {
+        reply.analytics = analytics;
         return;
       }
     }

--- a/solutions/frontend/src/utils/setAnalyticsForPath/index.ts
+++ b/solutions/frontend/src/utils/setAnalyticsForPath/index.ts
@@ -1,0 +1,34 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import type { PathsMap } from "../paths.js";
+import { paths } from "../paths.js";
+import { Scope } from "../../../../commons/utils/commonTypes.js";
+
+export const setAnalyticsForPath = async (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => {
+  const url = new URL(request.url, "http://localhost");
+  const scopes = Object.values(Scope);
+
+  for (const scope of scopes) {
+    const states = paths.journeys[scope];
+
+    for (const state of Object.values(states)) {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      for (const path of Object.values(state as PathsMap)) {
+        if (path.path === url.pathname && path.analytics) {
+          reply.analytics = path.analytics;
+          return;
+        }
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    for (const path of Object.values(paths.others as PathsMap)) {
+      if (path.path === url.pathname && path.analytics) {
+        reply.analytics = path.analytics;
+        return;
+      }
+    }
+  }
+};


### PR DESCRIPTION
Removes the analytics setting logic from the journey specific onRequest handler and adds it to a top-level onRequest handler so that analytics settings are correctly output for all journey and non-journey paths.