### PR TITLE
BAU: scope lng cookie to env

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -41,7 +41,6 @@ jobs:
           USE_LOCALSTACK=1
           SESSIONS_SIGNER=localsessionsignerwhichmustbeatleast32chars  
           SESSIONS_TABLE_NAME=amc-SessionStore
-          ROOT_DOMAIN=localhost
           ROOT_DOMAIN_WITH_ENV=localhost
           AWS_REGION=eu-west-2
           LOCALSTACK_ENDPOINT=http://localhost:4566

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -2369,8 +2369,6 @@ Resources:
         Variables:
           SESSIONS_SIGNER: !Sub "{{resolve:secretsmanager:${SessionSecret}:SecretString}}"
           SESSIONS_TABLE_NAME: !Sub ${AWS::StackName}-SessionStore
-          ROOT_DOMAIN:
-            !FindInMap [EnvironmentConfiguration, !Ref Environment, rootDomain]
           ROOT_DOMAIN_WITH_ENV:
             !FindInMap [
               EnvironmentConfiguration,

--- a/solutions/frontend/.env.integration-tests.sample
+++ b/solutions/frontend/.env.integration-tests.sample
@@ -3,7 +3,6 @@ NODE_ENV=production
 USE_LOCALSTACK=1
 SESSIONS_SIGNER=localsessionsignerwhichmustbeatleast32chars
 SESSIONS_TABLE_NAME=amc-SessionStore
-ROOT_DOMAIN=localhost
 ROOT_DOMAIN_WITH_ENV=localhost
 AWS_REGION=eu-west-2
 LOCALSTACK_ENDPOINT=http://localhost:4566

--- a/solutions/frontend/.env.sample
+++ b/solutions/frontend/.env.sample
@@ -3,7 +3,6 @@ NODE_ENV=production
 USE_LOCALSTACK=1
 SESSIONS_SIGNER=localsessionsignerwhichmustbeatleast32chars
 SESSIONS_TABLE_NAME=amc-SessionStore
-ROOT_DOMAIN=localhost
 ROOT_DOMAIN_WITH_ENV=localhost
 AWS_REGION=eu-west-2
 LOCALSTACK_ENDPOINT=http://localhost:4566

--- a/solutions/frontend/src/utils/configureI18n.test.ts
+++ b/solutions/frontend/src/utils/configureI18n.test.ts
@@ -9,7 +9,7 @@ vi.mock(import("../../../commons/utils/getEnvironment/index.js"), () => ({
 }));
 
 vi.mock(import("../../../commons/utils/constants.js"), () => ({
-  rootDomain: "account.gov.uk",
+  rootDomainWithEnv: "account.gov.uk",
 }));
 
 // @ts-expect-error

--- a/solutions/frontend/src/utils/configureI18n.ts
+++ b/solutions/frontend/src/utils/configureI18n.ts
@@ -1,7 +1,7 @@
 import i18next from "i18next";
 import { LanguageDetector } from "i18next-http-middleware";
 import { getEnvironment } from "../../../commons/utils/getEnvironment/index.js";
-import { rootDomain } from "../../../commons/utils/constants.js";
+import { rootDomainWithEnv } from "../../../commons/utils/constants.js";
 
 export enum Lang {
   English = "en",
@@ -27,7 +27,7 @@ export const configureI18n = async (translations: Record<Lang, object>) => {
       ignoreCase: true,
       caches: ["cookie"],
       cookieSecure: getEnvironment() !== "local",
-      cookieDomain: rootDomain,
+      cookieDomain: rootDomainWithEnv,
       cookieSameSite: "none",
     },
   });


### PR DESCRIPTION
Scopes the `lng` cookie to `{env}.account.gov.uk`. This aligns the behaviour with auth and will prevent some issues where it looks like language functionality isn't working properly in lower environments due to conflicting cookies.

It won't solve the issue of the user having multiple `lng` cookies if the user has visited both prod and a lower environment. In this case the user will have two cookies, one scoped to `account.gov.uk` and another to `{env}.account.gov.uk` and this may cause unexpected behaviours. These behaviours only occur in lower environments and it is a preexisting problem which this PR does not attempt to address.