### PR TITLE
BAU: move passkey failure error validation

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -49,7 +49,8 @@ vi.mock(import("../../utils/journeyActions.js"), async (importOriginal) => ({
   completeJourneyActionUnsuccessfully: mockCompleteJourneyActionUnsuccessfully,
 }));
 
-vi.mock(import("../utils/auditEvents/index.js"), () => ({
+vi.mock(import("../utils/auditEvents/index.js"), async (importOriginal) => ({
+  ...(await importOriginal()),
   sendPasskeyRegistrationGeneratedAuditEvent:
     mockSendPasskeyRegistrationGeneratedAuditEvent,
   sendPasskeyRegistrationFailedAuditEvent:
@@ -940,12 +941,12 @@ describe("passkey-create handlers", () => {
         );
         expect(mockReply.analytics).toStrictEqual(
           expect.objectContaining({
-            reason: "Client error occurred",
+            reason: "UnknownError",
           }),
         );
         expect(
           mockSendPasskeyRegistrationFailedAuditEvent,
-        ).toHaveBeenCalledWith(mockRequest, mockReply, "Client error occurred");
+        ).toHaveBeenCalledWith(mockRequest, mockReply, "UnknownError");
         expect(
           mockSendPasskeyRegistrationFailedAuditEvent,
         ).toHaveBeenCalledTimes(1);

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -262,17 +262,17 @@ export async function postHandler(
     metrics.addMetadata("ClientErrorName", body.registrationError);
     addErrorMetric("ClientError");
 
-    const knownError = v.parse(
+    const reason = v.parse(
       v.fallback(v.picklist(passkeyRegistrationFailureReason), "UnknownError"),
       body.registrationError,
     );
 
     reply.analytics = {
       ...reply.analytics,
-      reason: knownError,
+      reason,
     };
 
-    await sendPasskeyRegistrationFailedAuditEvent(request, reply, knownError);
+    await sendPasskeyRegistrationFailedAuditEvent(request, reply, reason);
 
     await render(request, reply, {
       showErrorUi: true,

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -36,6 +36,7 @@ import {
   sendPasskeyRegistrationSuccessfulAuditEvent,
   sendPasskeyEnrolmentFailedAuditEvent,
   sendPasskeyEnrolmentSuccessfulAuditEvent,
+  passkeyRegistrationFailureReason,
 } from "../utils/auditEvents/index.js";
 
 export const postBodySchema = v.object({
@@ -261,16 +262,17 @@ export async function postHandler(
     metrics.addMetadata("ClientErrorName", body.registrationError);
     addErrorMetric("ClientError");
 
-    reply.analytics = {
-      ...reply.analytics,
-      reason: body.registrationError,
-    };
-
-    await sendPasskeyRegistrationFailedAuditEvent(
-      request,
-      reply,
+    const knownError = v.parse(
+      v.fallback(v.picklist(passkeyRegistrationFailureReason), "UnknownError"),
       body.registrationError,
     );
+
+    reply.analytics = {
+      ...reply.analytics,
+      reason: knownError,
+    };
+
+    await sendPasskeyRegistrationFailedAuditEvent(request, reply, knownError);
 
     await render(request, reply, {
       showErrorUi: true,

--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
@@ -284,29 +284,13 @@ describe("passkey-create audit events", () => {
       );
     });
 
-    it("falls back to UnknownError when reason is not a known error", async () => {
-      await sendPasskeyRegistrationFailedAuditEvent(
-        mockRequest as FastifyRequest,
-        mockReply as FastifyReply,
-        "ClientError",
-      );
-
-      const eventPayload = mockCreateEvent.mock.calls[0]?.[1];
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      expect(eventPayload.extensions.passkey).toHaveProperty(
-        "passkey_registration_failure_reason",
-        "UnknownError",
-      );
-    });
-
     it("returns early when awsLambda event is not present", async () => {
       delete mockRequest.awsLambda;
 
       await sendPasskeyRegistrationFailedAuditEvent(
         mockRequest as FastifyRequest,
         mockReply as FastifyReply,
-        "ClientError",
+        "UnknownError",
       );
 
       expect(mockSendAuditEvent).not.toHaveBeenCalled();
@@ -319,7 +303,7 @@ describe("passkey-create audit events", () => {
         sendPasskeyRegistrationFailedAuditEvent(
           mockRequest as FastifyRequest,
           mockReply as FastifyReply,
-          "ClientError",
+          "UnknownError",
         ),
       ).rejects.toThrow();
     });

--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
@@ -12,7 +12,20 @@ import {
   type postBodySchema,
 } from "../../handlers/create.js";
 import type { InferOutput } from "valibot";
-import * as v from "valibot";
+
+export const passkeyRegistrationFailureReason = [
+  "InvalidRequestBody",
+  "JavaScriptNotEnabled",
+  "BrowserDoesNotSupportWebAuthn",
+  "AbortError",
+  "ConstraintError",
+  "InvalidStateError",
+  "NotAllowedError",
+  "NotSupportedError",
+  "SecurityError",
+  "TypeError",
+  "UnknownError",
+] as const;
 
 const buildRegistrationRequest = (
   registrationOptions: PublicKeyCredentialCreationOptionsJSON,
@@ -163,30 +176,10 @@ export const sendPasskeyRegistrationGeneratedAuditEvent = async (
 export const sendPasskeyRegistrationFailedAuditEvent = async (
   request: FastifyRequest,
   reply: FastifyReply,
-  reason: string,
+  reason: (typeof passkeyRegistrationFailureReason)[number],
 ) => {
   const base = getBaseEventProps(request, reply);
   if (!base) return;
-
-  const parsedReason = v.parse(
-    v.fallback(
-      v.picklist([
-        "InvalidRequestBody",
-        "JavaScriptNotEnabled",
-        "BrowserDoesNotSupportWebAuthn",
-        "AbortError",
-        "ConstraintError",
-        "InvalidStateError",
-        "NotAllowedError",
-        "NotSupportedError",
-        "SecurityError",
-        "TypeError",
-        "UnknownError",
-      ]),
-      "UnknownError",
-    ),
-    reason,
-  );
 
   await sendAuditEvent(
     createEvent("AMC_PASSKEY_REGISTRATION_FAILED", {
@@ -196,8 +189,8 @@ export const sendPasskeyRegistrationFailedAuditEvent = async (
       extensions: {
         "journey-type": base.journeyType,
         passkey: {
-          // @ts-expect-error - will error until "JavaScriptNotEnabled" and "BrowserDoesNotSupportWebAuthn" are added to the failure reasons type. Once they have been added then this comment can be removed.
-          passkey_registration_failure_reason: parsedReason,
+          // @ts-expect-error - will error until "InvalidRequestBody", "JavaScriptNotEnabled" and "BrowserDoesNotSupportWebAuthn" are added to the failure reasons type. Once they have been added then this comment can be removed.
+          passkey_registration_failure_reason: reason,
         },
       },
       user: base.user,


### PR DESCRIPTION
Move the validation for the passkey registration failure reason to the passkey create POST handler rather than handling it in the audit event function itself. The audit event function now only accepts valid reasons and doesn't have to perform its own validation.