### PR TITLE
BAU: correct property name in audit events

### DIFF
--- a/solutions/frontend/src/journeys/utils/completeJourney.test.ts
+++ b/solutions/frontend/src/journeys/utils/completeJourney.test.ts
@@ -464,7 +464,7 @@ describe("completeJourney", () => {
           account_actions: ["testing-journey-action"],
           account_actions_errors: [],
           account_actions_failed: [],
-          account_action_overall_outcome: true,
+          account_action_overall_success: true,
         }),
       }),
     );
@@ -521,7 +521,7 @@ describe("completeJourney", () => {
           account_actions: ["account-delete"],
           account_actions_errors: ["UserSignedOut"],
           account_actions_failed: ["account-delete"],
-          account_action_overall_outcome: false,
+          account_action_overall_success: false,
         }),
       }),
     );
@@ -587,7 +587,7 @@ describe("completeJourney", () => {
           account_actions: ["account-delete", "passkey-create"],
           account_actions_errors: ["UserSignedOut", "UserAbortedJourney"],
           account_actions_failed: ["account-delete", "passkey-create"],
-          account_action_overall_outcome: false,
+          account_action_overall_success: false,
         }),
       }),
     );

--- a/solutions/frontend/src/journeys/utils/completeJourney.ts
+++ b/solutions/frontend/src/journeys/utils/completeJourney.ts
@@ -132,7 +132,7 @@ export const completeJourney = async (
               if ("error" in action) errors.push(action.action);
               return errors;
             }, []),
-            account_action_overall_outcome: successOrOutcomeId,
+            account_action_overall_success: successOrOutcomeId,
           },
           user: {
             ...commonAuditEventProps.user,

--- a/solutions/frontend/src/journeys/utils/journeyActions.test.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.test.ts
@@ -222,7 +222,7 @@ describe("journeyActions", () => {
           event_name: "AMC_ACTION_COMPLETED",
           extensions: expect.objectContaining({
             account_action: "account-delete",
-            account_action_overall_outcome: true,
+            account_action_overall_success: true,
           }),
         }),
       );
@@ -343,7 +343,7 @@ describe("journeyActions", () => {
           event_name: "AMC_ACTION_COMPLETED",
           extensions: expect.objectContaining({
             account_action: "account-delete",
-            account_action_overall_outcome: false,
+            account_action_overall_success: false,
             account_action_error: "UserSignedOut",
           }),
         }),

--- a/solutions/frontend/src/journeys/utils/journeyActions.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.ts
@@ -189,7 +189,7 @@ const sendCompletedActionAuditEvent = async (
         extensions: {
           // @ts-expect-error - type in event catalogue seems to be incorrect
           account_action: action.name,
-          account_action_overall_outcome: action.success,
+          account_action_overall_success: action.success,
           account_action_error: action.success ? undefined : action.error,
           // @ts-expect-error - scope in event catalogue does not accommodate testing-journey scope
           amc_scope: request.session.claims.scope,


### PR DESCRIPTION
Renames all instances of `account_action_overall_outcome` to `account_action_overall_success` to match the event catalogue