### PR TITLE
BAU: Add zizmor ignore rule for git submodule ecosystem

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -130,7 +130,7 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
 
-  - package-ecosystem: "gitsubmodule"
+  - package-ecosystem: "gitsubmodule" # zizmor: ignore[dependabot-cooldown]
     directories:
       - "/"
     schedule:


### PR DESCRIPTION
On the pre commit checks, zizmor is flagging up that there is no cooldown configuration on the dependabot config for git submodules.

This was done on purpose as we want to receive passkey metadata submodule updates as soon as they are published.

This commit adds an inline ignore rule which should stop the zizmor precommit check from flagging the absence of a cooldown rule on submodule updates.