### PR TITLE
BAU: allow overriding AAGUID to facilitate testing

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -129,6 +129,7 @@ describe("passkey-create handlers", () => {
         claims: mockClaims,
       } as FastifySessionObject,
       body: {},
+      cookies: {},
       log: {
         warn: vi.fn(),
       } as unknown as FastifyRequest["log"],
@@ -827,6 +828,64 @@ describe("passkey-create handlers", () => {
           "PasskeyCreateError",
           "Count",
           1,
+        );
+      });
+
+      it("should use temp_aaguid_override cookie when present", async () => {
+        // @ts-expect-error
+        mockRequest.session.journeyActions = [{ action: "passkey-create" }];
+        mockRequest.cookies = { temp_aaguid_override: "override-aaguid" };
+
+        await postHandler(
+          mockRequest as FastifyRequest,
+          mockReply as FastifyReply,
+        );
+
+        expect(mockCreatePasskey).toHaveBeenCalledWith(
+          "user-123",
+          expect.objectContaining({
+            aaguid: "override-aaguid",
+          }),
+        );
+        expect(mockGetPasskeyConvenienceMetadataByAaguid).toHaveBeenCalledWith(
+          "override-aaguid",
+        );
+        expect(mockCompleteJourneyActionSuccessfully).toHaveBeenCalledWith(
+          {
+            action: "passkey-create",
+            details: { aaguid: "override-aaguid" },
+          },
+          mockRequest,
+          mockReply,
+        );
+      });
+
+      it("should fall back to registrationInfo aaguid when temp_aaguid_override cookie is empty", async () => {
+        // @ts-expect-error
+        mockRequest.session.journeyActions = [{ action: "passkey-create" }];
+        mockRequest.cookies = { temp_aaguid_override: "" };
+
+        await postHandler(
+          mockRequest as FastifyRequest,
+          mockReply as FastifyReply,
+        );
+
+        expect(mockCreatePasskey).toHaveBeenCalledWith(
+          "user-123",
+          expect.objectContaining({
+            aaguid: "aaguid-123",
+          }),
+        );
+        expect(mockGetPasskeyConvenienceMetadataByAaguid).toHaveBeenCalledWith(
+          "aaguid-123",
+        );
+        expect(mockCompleteJourneyActionSuccessfully).toHaveBeenCalledWith(
+          {
+            action: "passkey-create",
+            details: { aaguid: "aaguid-123" },
+          },
+          mockRequest,
+          mockReply,
         );
       });
 

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -394,6 +394,10 @@ export async function postHandler(
     return reply;
   }
 
+  const tempAaguidToUse = request.cookies["temp_aaguid_override"]?.length
+    ? request.cookies["temp_aaguid_override"]
+    : verification.registrationInfo.aaguid;
+
   const savePasskeyResult = await accountDataApiClient.createPasskey(
     request.session.claims.public_sub,
     {
@@ -401,7 +405,7 @@ export async function postHandler(
         verification.registrationInfo.credential.publicKey,
       ).toString("base64url"),
       id: verification.registrationInfo.credential.id,
-      aaguid: verification.registrationInfo.aaguid,
+      aaguid: tempAaguidToUse,
       isAttested: attestationSignature !== undefined,
       signCount: verification.registrationInfo.credential.counter,
       transports: verification.registrationInfo.credential.transports ?? [],
@@ -425,9 +429,7 @@ export async function postHandler(
   }
 
   const passkeyConvenienceMetadata =
-    await getPasskeyConvenienceMetadataByAaguid(
-      verification.registrationInfo.aaguid,
-    );
+    await getPasskeyConvenienceMetadataByAaguid(tempAaguidToUse);
 
   await sendNotification(
     passkeyConvenienceMetadata
@@ -454,7 +456,7 @@ export async function postHandler(
   await completeJourneyActionSuccessfully<"passkeyCreate">(
     {
       action: "passkey-create",
-      details: { aaguid: verification.registrationInfo.aaguid },
+      details: { aaguid: tempAaguidToUse },
     },
     request,
     reply,


### PR DESCRIPTION
These changes allow overriding the AAGUID for a passkey by passing an override value in a cookie. This is to facilitate the testing of adding and removing passkeys with unknown AAGUIDs. These changes will be reverted once testing is complete.