### PR TITLE
BAU: return correct access token expiry

### DIFF
--- a/solutions/api/src/lambda/token/index.test.ts
+++ b/solutions/api/src/lambda/token/index.test.ts
@@ -49,6 +49,11 @@ const mockCreateAccessToken = vi.mocked(
   await import("./utils/createAccessToken.js"),
 ).createAccessToken;
 
+vi.mock(import("../../../../commons/utils/getAppConfig/index.js"));
+const mockGetAppConfig = vi.mocked(
+  await import("../../../../commons/utils/getAppConfig/index.js"),
+).getAppConfig;
+
 vi.mock(import("./utils/assertTokenRequest.js"));
 const mockAssertTokenRequest = vi.mocked(
   await import("./utils/assertTokenRequest.js"),
@@ -73,6 +78,10 @@ describe("token handler", () => {
     mockAssertTokenRequest.mockImplementation(() => {
       // Empty implementation for successful validation
     });
+
+    mockGetAppConfig.mockResolvedValue({
+      access_token_max_age: 180,
+    } as Awaited<ReturnType<typeof mockGetAppConfig>>);
 
     // Mock error manager to return proper error responses
     mockErrorManager.handleError.mockReturnValue({
@@ -146,7 +155,7 @@ describe("token handler", () => {
       body: {
         access_token: "mock-access-token",
         token_type: "Bearer",
-        expires_in: 300,
+        expires_in: 180,
       },
     });
   });

--- a/solutions/api/src/lambda/token/index.ts
+++ b/solutions/api/src/lambda/token/index.ts
@@ -16,6 +16,7 @@ import { createAccessToken } from "./utils/createAccessToken.js";
 import { getApiBaseUrlWithStage } from "../../utils/common.js";
 import { normalizeAPIGatewayProxyEventHandlerWrapper } from "../../../../commons/utils/normalizeAPIGatewayProxyEventHandlerWrapper/index.js";
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import { getAppConfig } from "../../../../commons/utils/getAppConfig/index.js";
 
 export const handler = normalizeAPIGatewayProxyEventHandlerWrapper(
   loggerAPIGatewayProxyHandlerWrapper(
@@ -48,6 +49,8 @@ export const handler = normalizeAPIGatewayProxyEventHandlerWrapper(
 
           const accessToken = await createAccessToken(authRequest, apiBaseUrl);
 
+          const appConfig = await getAppConfig();
+
           return {
             statusCode: 200,
             headers: {
@@ -56,7 +59,7 @@ export const handler = normalizeAPIGatewayProxyEventHandlerWrapper(
             body: JSON.stringify({
               access_token: accessToken,
               token_type: "Bearer",
-              expires_in: 300,
+              expires_in: appConfig.access_token_max_age,
             }),
           };
         } catch (error) {


### PR DESCRIPTION
Rather than returning a hardcoded 300 for the access token expiry return the actual expiry from config