### PR TITLE
OLH-4249: analytics fixes

### DIFF
--- a/solutions/commons/utils/constants.ts
+++ b/solutions/commons/utils/constants.ts
@@ -30,3 +30,8 @@ export const passkeyDetailsSchema = v.object({
 
 export const rootDomain = process.env["ROOT_DOMAIN"];
 export const rootDomainWithEnv = process.env["ROOT_DOMAIN_WITH_ENV"];
+
+export enum Lang {
+  English = "en",
+  Welsh = "cy",
+}

--- a/solutions/commons/utils/fastify/render/index.test.ts
+++ b/solutions/commons/utils/fastify/render/index.test.ts
@@ -42,6 +42,7 @@ describe("render", () => {
       request: {
         i18n: {
           t: vi.fn(),
+          getFixedT: vi.fn().mockReturnValue(vi.fn()),
         } as unknown as typeof i18next,
       } as FastifyRequest,
       cspNonce: {
@@ -105,6 +106,11 @@ describe("render", () => {
     expect(mockEnv.addFilter).toHaveBeenCalledWith(
       "translate",
       reply.request?.i18n.t,
+    );
+    expect(mockEnv.addFilter).toHaveBeenCalledWith(
+      "getFixedT_en",
+      (reply.request!.i18n.getFixedT as unknown as ReturnType<typeof vi.fn>)
+        .mock.results[0]?.value,
     );
     expect(mockEnv.addGlobal).toHaveBeenCalledWith("reply", reply);
     expect(mockEnv.addFilter).toHaveBeenCalledWith(

--- a/solutions/commons/utils/fastify/render/index.ts
+++ b/solutions/commons/utils/fastify/render/index.ts
@@ -3,6 +3,7 @@ import type { FastifyReply } from "fastify";
 import { addLanguageParam, contactUsUrl } from "@govuk-one-login/frontend-ui";
 import * as path from "node:path";
 import { getQueryParamsFromUrl } from "../../getQueryParamsFromUrl/index.js";
+import { Lang } from "../../constants.js";
 
 export const render = async function (
   this: FastifyReply,
@@ -26,6 +27,7 @@ export const render = async function (
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (this.request.i18n) {
     env.addFilter("translate", this.request.i18n.t);
+    env.addFilter("getFixedT_en", this.request.i18n.getFixedT(Lang.English));
   }
   env.addGlobal("cspNonce", this.cspNonce.script);
   env.addGlobal("styleNonce", this.cspNonce.style);

--- a/solutions/frontend/src/handlers/onError/index.njk
+++ b/solutions/frontend/src/handlers/onError/index.njk
@@ -1,5 +1,6 @@
 {% extends "templates/layout/base-page.njk" %}
 {% set pageTitleName = 'error.error500.title' | translate %}
+{% set englishPageTitleName = 'error.error500.title' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'error.error500.header' | translate }}</h1>

--- a/solutions/frontend/src/handlers/onNotFound/index.njk
+++ b/solutions/frontend/src/handlers/onNotFound/index.njk
@@ -1,6 +1,7 @@
 {% extends "templates/layout/base-page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% set pageTitleName = 'error.error404.title' | translate %}
+{% set englishPageTitleName = 'error.error404.title' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'error.error404.heading1' | translate }}</h1>

--- a/solutions/frontend/src/handlers/pageExpired/index.njk
+++ b/solutions/frontend/src/handlers/pageExpired/index.njk
@@ -1,6 +1,7 @@
 {% extends "templates/layout/base-page.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% set pageTitleName = 'error.timeoutError.title' | translate %}
+{% set englishPageTitleName = 'error.timeoutError.title' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'error.timeoutError.header' | translate }}</h1>

--- a/solutions/frontend/src/index.ts
+++ b/solutions/frontend/src/index.ts
@@ -14,6 +14,7 @@ import fastifyStatic from "@fastify/static";
 import * as path from "node:path";
 import {
   channelCookieName,
+  Lang,
   oneYearInSeconds,
 } from "../../commons/utils/constants.js";
 import staticHash from "./utils/static-hash.json" with { type: "json" };
@@ -30,7 +31,7 @@ import {
   handle as i18nextMiddlewareHandle,
 } from "i18next-http-middleware";
 import { getCurrentUrl } from "../../commons/utils/fastify/getCurrentUrl/index.js";
-import { configureI18n, Lang } from "./utils/configureI18n.js";
+import { configureI18n } from "./utils/configureI18n.js";
 import {
   frontendUiTranslationCy,
   frontendUiTranslationEn,

--- a/solutions/frontend/src/journeys/account-delete/templates/confirm.njk
+++ b/solutions/frontend/src/journeys/account-delete/templates/confirm.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'journey:confirm.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:confirm.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'journey:confirm.heading' | translate }}</h1>

--- a/solutions/frontend/src/journeys/account-delete/templates/enterPassword.njk
+++ b/solutions/frontend/src/journeys/account-delete/templates/enterPassword.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'journey:enterPassword.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:enterPassword.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <form method="post">

--- a/solutions/frontend/src/journeys/account-delete/templates/introduction.njk
+++ b/solutions/frontend/src/journeys/account-delete/templates/introduction.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'journey:introduction.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:introduction.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'journey:introduction.heading' | translate }}</h1>

--- a/solutions/frontend/src/journeys/account-delete/templates/resendEmailVerificationCode.njk
+++ b/solutions/frontend/src/journeys/account-delete/templates/resendEmailVerificationCode.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'journey:resendEmailVerificationCode.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:resendEmailVerificationCode.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'journey:resendEmailVerificationCode.heading' | translate }}</h1>

--- a/solutions/frontend/src/journeys/account-delete/templates/verifyEmailAddress.njk
+++ b/solutions/frontend/src/journeys/account-delete/templates/verifyEmailAddress.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitleName = 'journey:verifyEmailAddress.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:verifyEmailAddress.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'journey:verifyEmailAddress.heading' | translate }}</h1>

--- a/solutions/frontend/src/journeys/passkey-create/templates/create.njk
+++ b/solutions/frontend/src/journeys/passkey-create/templates/create.njk
@@ -6,10 +6,12 @@
 
 {% if showErrorUi %}        
   {% set pageTitleName = ['journey:create.error.pageTitle', stringsSuffix] | join | translate %}
+  {% set englishPageTitleName = ['journey:create.error.pageTitle', stringsSuffix] | join | getFixedT_en %}
   {% set heading = ['journey:create.error.heading', stringsSuffix] | join | translate %}
   {% set submitButtonLabel = ['journey:create.error.buttonLabel', stringsSuffix] | join | translate %}      
 {% else %}  
   {% set pageTitleName = ['journey:create.pageTitle', stringsSuffix] | join | translate %}
+  {% set englishPageTitleName = ['journey:create.pageTitle', stringsSuffix] | join | getFixedT_en %}
   {% set heading = ['journey:create.heading', stringsSuffix] | join | translate %}  
   {% set submitButtonLabel = ['journey:create.buttonLabel', stringsSuffix] | join | translate %}    
 {% endif %}

--- a/solutions/frontend/src/journeys/testing-journey/confirm.njk
+++ b/solutions/frontend/src/journeys/testing-journey/confirm.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'journey:confirm.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:confirm.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'journey:confirm.heading' | translate }}</h1>

--- a/solutions/frontend/src/journeys/testing-journey/enterPassword.njk
+++ b/solutions/frontend/src/journeys/testing-journey/enterPassword.njk
@@ -3,6 +3,7 @@
 {% from "templates/common/password-input-macro.njk" import govukInputWithShowPassword %}
 
 {% set pageTitleName = 'journey:enterPassword.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:enterPassword.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'journey:enterPassword.heading' | translate }}</h1>

--- a/solutions/frontend/src/journeys/testing-journey/step1.njk
+++ b/solutions/frontend/src/journeys/testing-journey/step1.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitleName = 'journey:step1.pageTitle' | translate %}
+{% set englishPageTitleName = 'journey:step1.pageTitle' | getFixedT_en %}
 
 {% block pageContent %}
   <h1 class="govuk-heading-l">{{ 'journey:step1.heading' | translate }}</h1>

--- a/solutions/frontend/src/journeys/utils/config.test.ts
+++ b/solutions/frontend/src/journeys/utils/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { journeys } from "./config.js";
-import { Lang } from "../../utils/configureI18n.js";
 import { Scope } from "../../../../commons/utils/commonTypes.js";
+import { Lang } from "../../../../commons/utils/constants.js";
 
 // @ts-expect-error
 vi.mock(import("./stateMachines/testing-journey.js"), () => ({

--- a/solutions/frontend/src/journeys/utils/config.ts
+++ b/solutions/frontend/src/journeys/utils/config.ts
@@ -1,8 +1,8 @@
 import { type getClaimsSchema } from "../../utils/getClaimsSchema.js";
-import { Lang } from "../../utils/configureI18n.js";
 import type { AnyStateMachine } from "xstate";
 import type * as v from "valibot";
 import { Scope } from "../../../../commons/utils/commonTypes.js";
+import { Lang } from "../../../../commons/utils/constants.js";
 
 export const journeys = {
   [Scope.testingJourney]: async () => {

--- a/solutions/frontend/src/templates/layout/base.njk
+++ b/solutions/frontend/src/templates/layout/base.njk
@@ -27,6 +27,15 @@
   {% endif -%}
   {{ 'general.serviceNameTitle' | translate if not hideTitleProductName}}
 {%- endblock %}
+{%- set englishPageTitleFull -%}
+  {%- if error or errors %} {{ 'general.errorTitlePrefix' | getFixedT_en }} - {% endif -%}
+  {%- if englishPageTitleName -%}
+      {{ englishPageTitleName }}
+      {%- if not hideTitleProductName %} - {% endif -%}
+  {% endif -%}
+  {{ 'general.serviceNameTitle' | getFixedT_en if not hideTitleProductName}}
+{%- endset -%}
+
 {% block bodyStart %}
   {% include 'templates/layout/cookieBanner.njk' %}
 {% endblock %}
@@ -121,6 +130,7 @@
       window.addEventListener('load', function () {
         if (window.DI && window.DI.analyticsGa4) {
             window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+                englishPageTitle: "{{ englishPageTitleFull }}",
                 statusCode: {% if reply.statusCode %}{{ reply.statusCode }}{% else %}200{% endif %},
                 logged_in_status: {% if reply.client.consider_user_logged_in === true %}true{% else %}false{% endif %},
                 dynamic: {% if reply.analytics.dynamic === false %}false{% else %}true{% endif %},

--- a/solutions/frontend/src/templates/layout/base.njk
+++ b/solutions/frontend/src/templates/layout/base.njk
@@ -122,13 +122,13 @@
         if (window.DI && window.DI.analyticsGa4) {
             window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
                 statusCode: {% if reply.statusCode %}{{ reply.statusCode }}{% else %}200{% endif %},
-                taxonomy_level1: "{{ reply.analytics.taxonomyLevel1 }}",
-                taxonomy_level2: "{{ reply.analytics.taxonomyLevel2 }}",
-                taxonomy_level3: "{{ reply.analytics.taxonomyLevel3 }}",
-                content_id: "{{ reply.analytics.contentId }}",
                 logged_in_status: {% if reply.client.consider_user_logged_in === true %}true{% else %}false{% endif %},
                 dynamic: {% if reply.analytics.dynamic === false %}false{% else %}true{% endif %},
-                reason: "{{ reply.analytics.reason }}",
+                {% if reply.analytics.taxonomyLevel1 %}taxonomy_level1: "{{ reply.analytics.taxonomyLevel1 }}",{% endif %}
+                {% if reply.analytics.taxonomyLevel2 %}taxonomy_level2: "{{ reply.analytics.taxonomyLevel2 }}",{% endif %}
+                {% if reply.analytics.taxonomyLevel3 %}taxonomy_level3: "{{ reply.analytics.taxonomyLevel3 }}",{% endif %}
+                {% if reply.analytics.contentId %}content_id: "{{ reply.analytics.contentId }}",{% endif %}                
+                {% if reply.analytics.reason %}reason: "{{ reply.analytics.reason }}",{% endif %}
             });
         }
       });

--- a/solutions/frontend/src/utils/configureI18n.test.ts
+++ b/solutions/frontend/src/utils/configureI18n.test.ts
@@ -1,16 +1,24 @@
 import { expect, it, describe, vi, beforeEach, afterEach } from "vitest";
-import { configureI18n, Lang } from "./configureI18n.js";
+import { configureI18n } from "./configureI18n.js";
 import i18next from "i18next";
 import { LanguageDetector } from "i18next-http-middleware";
 import { getEnvironment } from "../../../commons/utils/getEnvironment/index.js";
+import { Lang } from "../../../commons/utils/constants.js";
 
 vi.mock(import("../../../commons/utils/getEnvironment/index.js"), () => ({
   getEnvironment: vi.fn(),
 }));
 
-vi.mock(import("../../../commons/utils/constants.js"), () => ({
-  rootDomainWithEnv: "account.gov.uk",
-}));
+vi.mock(
+  import("../../../commons/utils/constants.js"),
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    return {
+      ...actual,
+      rootDomainWithEnv: "account.gov.uk",
+    };
+  },
+);
 
 // @ts-expect-error
 vi.mock(import("i18next"), () => {

--- a/solutions/frontend/src/utils/configureI18n.ts
+++ b/solutions/frontend/src/utils/configureI18n.ts
@@ -1,12 +1,7 @@
 import i18next from "i18next";
 import { LanguageDetector } from "i18next-http-middleware";
 import { getEnvironment } from "../../../commons/utils/getEnvironment/index.js";
-import { rootDomainWithEnv } from "../../../commons/utils/constants.js";
-
-export enum Lang {
-  English = "en",
-  Welsh = "cy",
-}
+import { Lang, rootDomainWithEnv } from "../../../commons/utils/constants.js";
 
 export const configureI18n = async (translations: Record<Lang, object>) => {
   await i18next.use(LanguageDetector).init({


### PR DESCRIPTION
Updates the analytics code in the Nunjucks base template to only output certain properties if they're defined.

Also includes changes to send the English page title in analytics page load events.