### PR TITLE
BAU: remove workflow dispatch skip

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -113,7 +113,6 @@ jobs:
           # cfn-lint still runs against this template via the cfnlint CI step.
           # See: https://github.com/bridgecrewio/checkov/issues/6804
           skip_path: solutions/app-infra/template.yaml
-          # CKV_GHA_7 flags workflow_dispatch inputs but these workflows use gitRef solely
           # to select the deployment revision, not to affect build output.
           # CKV2_GHA_1 flags missing top-level permissions but all jobs in affected workflows
           # already define their own explicit permissions, making a top-level block redundant.
@@ -126,4 +125,4 @@ jobs:
           # CKV_DOCKER_4 flags Dockerfiles using ADD instead of RUN curl and CKV_DOCKER_2
           # flags missing HEALTHCHECK instructions, created OLH-4094 to implement.
           # CKV_DOCKER_3: "need a non-user root user" is intentionally omitted as the integration tests container needs root permissions to run AWS CLI commands and install dependencies.
-          skip_check: CKV_GHA_7,CKV2_GHA_1,CKV_OPENAPI_21,CKV_OPENAPI_4,CKV_OPENAPI_5,CKV_AWS_18,CKV_AWS_111,CKV_AWS_124,CKV_DOCKER_2,CKV_DOCKER_3,CKV_DOCKER_4
+          skip_check: CKV2_GHA_1,CKV_OPENAPI_21,CKV_OPENAPI_4,CKV_OPENAPI_5,CKV_AWS_18,CKV_AWS_111,CKV_AWS_124,CKV_DOCKER_2,CKV_DOCKER_3,CKV_DOCKER_4

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -112,7 +112,7 @@ jobs:
           # inside SAM Globals causes a ValueError crash (invalid literal for int() with base 10: 'Fn::If').
           # cfn-lint still runs against this template via the cfnlint CI step.
           # See: https://github.com/bridgecrewio/checkov/issues/6804
-          skip_path: solutions/app-infra/template.yaml
+          skip_path: solutions/app-infra/template.yaml,submodules/.+
           # to select the deployment revision, not to affect build output.
           # CKV2_GHA_1 flags missing top-level permissions but all jobs in affected workflows
           # already define their own explicit permissions, making a top-level block redundant.

--- a/.github/workflows/deploy-config-dev.yaml
+++ b/.github/workflows/deploy-config-dev.yaml
@@ -1,5 +1,7 @@
 name: Deploy Configuration - dev
 
+# This pipeline deploys work-in-progress branches for dev work
+# checkov:skip=CKV_GHA_7:workflow_dispatch inputs are required to select the branch/tag to deploy
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy-to-dev.yaml
+++ b/.github/workflows/deploy-to-dev.yaml
@@ -1,5 +1,7 @@
 name: Deploy Application - dev
 
+# This pipeline deploys work-in-progress branches for dev work
+# checkov:skip=CKV_GHA_7:workflow_dispatch inputs are required to select the branch/tag to deploy
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Removes the global workflow dispatch Checkov skip and just adds comment skips where we explicitly want to use workflow dispatch actions.