### PR TITLE
BAU: disable exclude credentials

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -330,7 +330,7 @@ describe("passkey-create handlers", () => {
 
       expect(mockGenerateRegistrationOptions).toHaveBeenCalledWith(
         expect.objectContaining({
-          excludeCredentials: [{ id: "passkey-1" }, { id: "passkey-2" }],
+          //excludeCredentials: [{ id: "passkey-1" }, { id: "passkey-2" }],
           supportedAlgorithmIDs: [-7, -8, -257],
         }),
       );

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -55,7 +55,7 @@ export const supportedAlgorithmIDs = [
 const setRegistrationOptions = async (
   request: FastifyRequest,
   reply: FastifyReply,
-  idsOfCredentialsToExclude: string[],
+  //idsOfCredentialsToExclude: string[],
 ) => {
   assert.ok(request.session.claims);
   assert.ok(reply.journeyStates?.["passkey-create"]);
@@ -73,9 +73,9 @@ const setRegistrationOptions = async (
       userVerification: "required",
     },
     supportedAlgorithmIDs,
-    excludeCredentials: idsOfCredentialsToExclude.map((id) => ({
+    /*excludeCredentials: idsOfCredentialsToExclude.map((id) => ({
       id,
-    })),
+    })),*/
   });
 
   reply.journeyStates["passkey-create"].send({
@@ -124,7 +124,7 @@ const render = async (
   const registrationOptions = await setRegistrationOptions(
     request,
     reply,
-    getPasskeysResult.result.passkeys.map((pk) => pk.id),
+    //getPasskeysResult.result.passkeys.map((pk) => pk.id),
   );
 
   assert.ok(reply.render);


### PR DESCRIPTION
Temporarily disable exclude credentials when registering passkeys. This is to facilitate testing adding lots of passkeys without having lots of different authenticator types available. Once testing is complete this PR will be reverted.