### PR TITLE
BAU: analytics props changes

### DIFF
--- a/solutions/commons/utils/fastify/types.d.ts
+++ b/solutions/commons/utils/fastify/types.d.ts
@@ -64,6 +64,8 @@ declare module "fastify" {
           taxonomyLevel1?: string;
           taxonomyLevel2?: string;
           taxonomyLevel3?: string;
+          taxonomyLevel4?: string;
+          taxonomyLevel5?: string;
           dynamic?: boolean;
           isSelectContentTrackingEnabled?: boolean;
           reason?: string;

--- a/solutions/config/schema/config.json
+++ b/solutions/config/schema/config.json
@@ -69,6 +69,8 @@
         "taxonomyLevel1": { "type": "string" },
         "taxonomyLevel2": { "type": "string" },
         "taxonomyLevel3": { "type": "string" },
+        "taxonomyLevel4": { "type": "string" },
+        "taxonomyLevel5": { "type": "string" },
         "dynamic": { "type": "boolean" },
         "isSelectContentTrackingEnabled": { "type": "boolean" }
       },

--- a/solutions/frontend/src/templates/layout/base.njk
+++ b/solutions/frontend/src/templates/layout/base.njk
@@ -134,10 +134,12 @@
                 statusCode: {% if reply.statusCode %}{{ reply.statusCode }}{% else %}200{% endif %},
                 logged_in_status: {% if reply.client.consider_user_logged_in === true %}true{% else %}false{% endif %},
                 dynamic: {% if reply.analytics.dynamic === false %}false{% else %}true{% endif %},
-                {% if reply.analytics.taxonomyLevel1 %}taxonomy_level1: "{{ reply.analytics.taxonomyLevel1 }}",{% endif %}
-                {% if reply.analytics.taxonomyLevel2 %}taxonomy_level2: "{{ reply.analytics.taxonomyLevel2 }}",{% endif %}
+                taxonomy_level1: "{{ reply.analytics.taxonomyLevel1 }}",
+                taxonomy_level2: "{{ reply.analytics.taxonomyLevel2 }}",
                 {% if reply.analytics.taxonomyLevel3 %}taxonomy_level3: "{{ reply.analytics.taxonomyLevel3 }}",{% endif %}
-                {% if reply.analytics.contentId %}content_id: "{{ reply.analytics.contentId }}",{% endif %}                
+                {% if reply.analytics.taxonomyLevel4 %}taxonomy_level4: "{{ reply.analytics.taxonomyLevel4 }}",{% endif %}
+                {% if reply.analytics.taxonomyLevel5 %}taxonomy_level5: "{{ reply.analytics.taxonomyLevel5 }}",{% endif %}
+                content_id: "{{ reply.analytics.contentId }}",
                 {% if reply.analytics.reason %}reason: "{{ reply.analytics.reason }}",{% endif %}
             });
         }


### PR DESCRIPTION
The analytics properties `taxonomy_level1`, `taxonomy_level2` and `content_id` should always be sent event if they are just empty strings.

Also adds support for the `taxonomy_level4` and `taxonomy_level5` properties.