### PR TITLE
BAU: Dynatrace RUM and GA4 changes

### DIFF
--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -148,7 +148,7 @@ Mappings:
       passkeysExpectedOrigin: https://manage.staging.account.gov.uk
       yourServicesUrl: https://home.staging.account.gov.uk/your-services
       securityUrl: https://home.staging.account.gov.uk/security
-      dynatraceRumUrl: TODO
+      dynatraceRumUrl: ""
       accountDataApiUrl: https://7xgl7lexy4.execute-api.eu-west-2.amazonaws.com/staging
       notifyStubUrl: ""
       notifyTemplateIds: |
@@ -176,7 +176,7 @@ Mappings:
       frontendDomain: manage.integration.account.gov.uk
       authFrontendUrl: https://signin.integration.account.gov.uk
       analyticsCookieDomain: integration.account.gov.uk
-      ga4ContainerId: "TODO"
+      ga4ContainerId: ""
       analyticsEnabled: "0"
       accountManagementApiUrl: "https://0boxndhikk-vpce-0553cfc8fc1aeb970.execute-api.eu-west-2.amazonaws.com/integration"
       contactUrl: https://home.integration.account.gov.uk/contact-gov-uk-one-login
@@ -185,7 +185,7 @@ Mappings:
       passkeysExpectedOrigin: https://manage.integration.account.gov.uk
       yourServicesUrl: https://home.integration.account.gov.uk/your-services
       securityUrl: https://home.integration.account.gov.uk/security
-      dynatraceRumUrl: TODO
+      dynatraceRumUrl: ""
       accountDataApiUrl: https://hoidt6wujb.execute-api.eu-west-2.amazonaws.com/integration
       notifyStubUrl: ""
       notifyTemplateIds: |
@@ -222,7 +222,7 @@ Mappings:
       passkeysExpectedOrigin: https://manage.account.gov.uk
       yourServicesUrl: https://home.account.gov.uk/your-services
       securityUrl: https://home.account.gov.uk/security
-      dynatraceRumUrl: TODO
+      dynatraceRumUrl: ""
       accountDataApiUrl: https://0218o1p9tj.execute-api.eu-west-2.amazonaws.com/production
       notifyStubUrl: ""
       notifyTemplateIds: |

--- a/solutions/frontend/src/templates/layout/base.njk
+++ b/solutions/frontend/src/templates/layout/base.njk
@@ -108,45 +108,48 @@
     </script>
     <script src="/public/scripts/analytics.js?{{ globals.publicScriptsHash }}" nonce='{{ cspNonce }}'></script>
 
+    {% if globals.ga4ContainerId %}
     <script nonce='{{ cspNonce }}'>
-    if (window.DI) {
-      window.DI.appInit({
-        ga4ContainerId: "{{ globals.ga4ContainerId }}",
-      }, {
-        enableGa4Tracking: {% if globals.analyticsEnabled === true %}true{% else %}false{% endif %},
-        cookieDomain: "{{ globals.analyticsCookieDomain }}",
-        isDataSensitive: false,
-        isPageDataSensitive: {% if reply.analytics.isPageDataSensitive === true %}true{% else %}false{% endif %},
-        enablePageViewTracking: true,
-        enableFormResponseTracking: true,
-        enableFormChangeTracking: true,
-        enableFormErrorTracking: true,
-        enableNavigationTracking: true,
-        enableSelectContentTracking: {% if reply.analytics.isSelectContentTrackingEnabled === true %}true{% else %}false{% endif %},
-      });
-    }
+      if (window.DI) {
+        window.DI.appInit({
+          ga4ContainerId: "{{ globals.ga4ContainerId }}",
+        }, {
+          enableGa4Tracking: {% if globals.analyticsEnabled === true %}true{% else %}false{% endif %},
+          cookieDomain: "{{ globals.analyticsCookieDomain }}",
+          isDataSensitive: false,
+          isPageDataSensitive: {% if reply.analytics.isPageDataSensitive === true %}true{% else %}false{% endif %},
+          enablePageViewTracking: true,
+          enableFormResponseTracking: true,
+          enableFormChangeTracking: true,
+          enableFormErrorTracking: true,
+          enableNavigationTracking: true,
+          enableSelectContentTracking: {% if reply.analytics.isSelectContentTrackingEnabled === true %}true{% else %}false{% endif %},
+        });
+      }
 
-    {% if reply.analytics %}
-      window.addEventListener('load', function () {
-        if (window.DI && window.DI.analyticsGa4) {
-            window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
-                englishPageTitle: "{{ englishPageTitleFull }}",
-                statusCode: {% if reply.statusCode %}{{ reply.statusCode }}{% else %}200{% endif %},
-                logged_in_status: {% if reply.client.consider_user_logged_in === true %}true{% else %}false{% endif %},
-                dynamic: {% if reply.analytics.dynamic === false %}false{% else %}true{% endif %},
-                {% if reply.analytics.taxonomyLevel1 %}taxonomy_level1: "{{ reply.analytics.taxonomyLevel1 }}",{% endif %}
-                {% if reply.analytics.taxonomyLevel2 %}taxonomy_level2: "{{ reply.analytics.taxonomyLevel2 }}",{% endif %}
-                {% if reply.analytics.taxonomyLevel3 %}taxonomy_level3: "{{ reply.analytics.taxonomyLevel3 }}",{% endif %}
-                {% if reply.analytics.contentId %}content_id: "{{ reply.analytics.contentId }}",{% endif %}                
-                {% if reply.analytics.reason %}reason: "{{ reply.analytics.reason }}",{% endif %}
-            });
-        }
-      });
+      {% if reply.analytics %}
+        window.addEventListener('load', function () {
+          if (window.DI && window.DI.analyticsGa4) {
+              window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+                  englishPageTitle: "{{ englishPageTitleFull }}",
+                  statusCode: {% if reply.statusCode %}{{ reply.statusCode }}{% else %}200{% endif %},
+                  logged_in_status: {% if reply.client.consider_user_logged_in === true %}true{% else %}false{% endif %},
+                  dynamic: {% if reply.analytics.dynamic === false %}false{% else %}true{% endif %},
+                  {% if reply.analytics.taxonomyLevel1 %}taxonomy_level1: "{{ reply.analytics.taxonomyLevel1 }}",{% endif %}
+                  {% if reply.analytics.taxonomyLevel2 %}taxonomy_level2: "{{ reply.analytics.taxonomyLevel2 }}",{% endif %}
+                  {% if reply.analytics.taxonomyLevel3 %}taxonomy_level3: "{{ reply.analytics.taxonomyLevel3 }}",{% endif %}
+                  {% if reply.analytics.contentId %}content_id: "{{ reply.analytics.contentId }}",{% endif %}                
+                  {% if reply.analytics.reason %}reason: "{{ reply.analytics.reason }}",{% endif %}
+              });
+          }
+        });
+      {% endif %}
+    </script>
     {% endif %}
-  </script>
-  <script type="module" src="/fingerprint/index.js?{{ globals.fingerprintHash }}" nonce='{{ cspNonce }}'></script>
-  <script type="module" nonce='{{ cspNonce }}'>
-    import { setFingerprintCookie } from "/fingerprint/index.js?{{ globals.fingerprintHash }}";
-    setFingerprintCookie({% if globals.env === "local" %}"localhost"{% endif %});
-  </script>
+
+    <script type="module" src="/fingerprint/index.js?{{ globals.fingerprintHash }}" nonce='{{ cspNonce }}'></script>
+    <script type="module" nonce='{{ cspNonce }}'>
+      import { setFingerprintCookie } from "/fingerprint/index.js?{{ globals.fingerprintHash }}";
+      setFingerprintCookie({% if globals.env === "local" %}"localhost"{% endif %});
+    </script>
 {% endblock %}


### PR DESCRIPTION
The changes in this PR will appear to be much fewer if you enable the "hide whitespace" option (or go to https://github.com/govuk-one-login/account-components/pull/900/changes?w=1).

Where we don't have Dynatrace RUM URLs and GA4 container IDs set them to empty strings rather than "TODO".

Only output the Google Analytics script when `ga4ContainerId` is set.