### PR TITLE
OLH-4099: Checkov fixes

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -122,7 +122,4 @@ jobs:
           # CKV_AWS_18 flags missing S3 access logging and CKV_AWS_111 flags IAM policies
           # without write access constraints, created OLH-4093 to implement
           # CKV_AWS_124 Intentionally ommitted as SNS topics do not exist.
-          # CKV_DOCKER_4 flags Dockerfiles using ADD instead of RUN curl and CKV_DOCKER_2
-          # flags missing HEALTHCHECK instructions, created OLH-4094 to implement.
-          # CKV_DOCKER_3: "need a non-user root user" is intentionally omitted as the integration tests container needs root permissions to run AWS CLI commands and install dependencies.
-          skip_check: CKV2_GHA_1,CKV_OPENAPI_21,CKV_OPENAPI_4,CKV_OPENAPI_5,CKV_AWS_18,CKV_AWS_111,CKV_AWS_124,CKV_DOCKER_2,CKV_DOCKER_3,CKV_DOCKER_4
+          skip_check: CKV2_GHA_1,CKV_OPENAPI_21,CKV_OPENAPI_4,CKV_OPENAPI_5,CKV_AWS_18,CKV_AWS_111,CKV_AWS_124

--- a/solutions/integration-tests/Dockerfile
+++ b/solutions/integration-tests/Dockerfile
@@ -1,6 +1,8 @@
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
+
+#checkov:skip=CKV_DOCKER_3: Not applicable for development image
 FROM node:24.16.0-bookworm@sha256:8530f76a96d88820d288761f022e318970dda93d01536919fbc16076b7983e63
 
 RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \

--- a/solutions/integration-tests/Dockerfile
+++ b/solutions/integration-tests/Dockerfile
@@ -1,8 +1,8 @@
+#checkov:skip=CKV_DOCKER_3: Not applicable for development image
+
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
-
-#checkov:skip=CKV_DOCKER_3: Not applicable for development image
 FROM node:24.16.0-bookworm@sha256:8530f76a96d88820d288761f022e318970dda93d01536919fbc16076b7983e63
 
 RUN curl --proto =https -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \

--- a/solutions/integration-tests/Dockerfile
+++ b/solutions/integration-tests/Dockerfile
@@ -3,8 +3,10 @@
 # the tag allows Dependabot to evaluate version constraints
 FROM node:24.16.0-bookworm@sha256:8530f76a96d88820d288761f022e318970dda93d01536919fbc16076b7983e63
 
-ADD https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip awscliv2.zip
-RUN unzip awscliv2.zip && ./aws/install
+RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf awscliv2.zip aws
 ENV AWS_PAGER=""
 
 COPY package.json package.json
@@ -15,5 +17,7 @@ COPY .nvmrc .nvmrc
 RUN npm ci && npm run install-browsers
 
 COPY . .
+
+HEALTHCHECK NONE
 
 ENTRYPOINT [ "./run-tests.sh" ]

--- a/solutions/integration-tests/Dockerfile
+++ b/solutions/integration-tests/Dockerfile
@@ -5,7 +5,7 @@
 #checkov:skip=CKV_DOCKER_3: Not applicable for development image
 FROM node:24.16.0-bookworm@sha256:8530f76a96d88820d288761f022e318970dda93d01536919fbc16076b7983e63
 
-RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \
+RUN curl --proto =https -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o awscliv2.zip \
     && unzip awscliv2.zip \
     && ./aws/install \
     && rm -rf awscliv2.zip aws

--- a/solutions/localstack/local-kms/Dockerfile
+++ b/solutions/localstack/local-kms/Dockerfile
@@ -1,8 +1,8 @@
+#checkov:skip=CKV_DOCKER_3: Not applicable for development image
+
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
-
-#checkov:skip=CKV_DOCKER_3: Not applicable for development image
 FROM nsmithuk/local-kms:latest@sha256:e070866476b20973a9e23a9b636204b7a222e4169a6e03198d27b80d47ed28e3
 
 HEALTHCHECK NONE

--- a/solutions/localstack/local-kms/Dockerfile
+++ b/solutions/localstack/local-kms/Dockerfile
@@ -1,4 +1,8 @@
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
+
+#checkov:skip=CKV_DOCKER_3: Not applicable for development image
 FROM nsmithuk/local-kms:latest@sha256:e070866476b20973a9e23a9b636204b7a222e4169a6e03198d27b80d47ed28e3
+
+HEALTHCHECK NONE

--- a/solutions/localstack/localstack/Dockerfile
+++ b/solutions/localstack/localstack/Dockerfile
@@ -1,8 +1,8 @@
+#checkov:skip=CKV_DOCKER_3: Not applicable for development image
+
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
-
-#checkov:skip=CKV_DOCKER_3: Not applicable for development image
 FROM localstack/localstack:4.12.0@sha256:0df3a97da57de03a588c05d9b8f390f15c7033fc7c4512f94619d344bc3cd317
 
 HEALTHCHECK NONE

--- a/solutions/localstack/localstack/Dockerfile
+++ b/solutions/localstack/localstack/Dockerfile
@@ -1,4 +1,8 @@
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
+
+#checkov:skip=CKV_DOCKER_3: Not applicable for development image
 FROM localstack/localstack:4.12.0@sha256:0df3a97da57de03a588c05d9b8f390f15c7033fc7c4512f94619d344bc3cd317
+
+HEALTHCHECK NONE


### PR DESCRIPTION
Removes the global skip rules for CKV_DOCKER_2, CKV_DOCKER_3, CKV_DOCKER_4.

Addresses the CKV_DOCKER_4 issue by using `RUN` instead of `ADD` to install the AWS CLI.

Addresses the CKV_DOCKER_2 issues by adding `HEALTHCHECK NONE` to all Dockerfiles.

Adds inline skips for CKV_DOCKER_3 to all Dockerfiles. As all Dockerfiles are for development it is not an issue to use the root user.


