### PR TITLE
OLH-4311: alarm and dashboard improvements

### DIFF
--- a/runbooks/api-alarms-runbook.md
+++ b/runbooks/api-alarms-runbook.md
@@ -10,6 +10,12 @@ This runbook covers the following second line production alarms for the Account 
 - [ApiJourneyOutcomeLambdaErrorsAlarm](#apijourneyoutcomelambdaerrorsalarm)
 - [ApiJourneyOutcomeLambdaLogErrorAlarm](#apijourneyoutcomelambdalogerroralarm)
 
+## AWS Account
+
+Account: **di-account-components-prod** (494066295151)
+
+Dashboard: [amc-dashboard](https://uk-digital-identity.awsapps.com/start/#/console?account_id=494066295151&role_name=ApprovedServiceSupport&destination=https%3A%2F%2Feu-west-2.console.aws.amazon.com%2Fcloudwatch%2Fhome%3Fregion%3Deu-west-2%23dashboards%2Fdashboard%2Famc-dashboard)
+
 ## Context
 
 AMC provides reusable account journeys which are initiated from either:

--- a/runbooks/api-alarms-runbook.md
+++ b/runbooks/api-alarms-runbook.md
@@ -1,0 +1,113 @@
+# API Alarms Runbook
+
+## Overview
+
+This runbook covers the following second line production alarms for the Account Management Components (AMC) private API:
+
+- [ApiApiGateway5XXErrorsAlarm](#apiapigateway5xxerrorsalarm)
+- [ApiTokenLambdaErrorsAlarm](#apitokenlambdaerrorsalarm)
+- [ApiTokenLambdaLogErrorAlarm](#apitokenlambdalogerroralarm)
+- [ApiJourneyOutcomeLambdaErrorsAlarm](#apijourneyoutcomelambdaerrorsalarm)
+- [ApiJourneyOutcomeLambdaLogErrorAlarm](#apijourneyoutcomelambdalogerroralarm)
+
+## Context
+
+AMC provides reusable account journeys which are initiated from either:
+
+- An **Authentication (sign in/sign up) journey** — handed off from the Auth client
+- **Account management (Home)** — handed off from the Home client
+
+When a user finishes an AMC journey they are redirected back to the client's callback with an authorization code. The client can then:
+
+1. Make a request to the `/token` endpoint to exchange the authorization code for a token.
+2. Use the token to make a request to the `/journeyoutcome` endpoint to get details of the user's completed journey.
+
+These endpoints form the private API and are consumed by the Auth and Home clients.
+
+Journeys supported:
+
+- Passkey creation during sign in
+- Passkey creation from account management
+
+## Owning Team
+
+These alarms are owned by the **Home team** in the **Accounts pod**.
+
+Slack channel: **[#di-one-login-home-tech](https://gds.slack.com/archives/C011Y5SAY3U)**
+
+Resolution will likely need to be done by the Home team.
+
+## Alarms
+
+### ApiApiGateway5XXErrorsAlarm
+
+**What it means:** The private API Gateway is returning more server errors (5XX) than expected.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard for an overview of API health.
+2. Check the API Lambda logs at `/aws/lambda/amc/ApiTokenLambda` and `/aws/lambda/amc/ApiJourneyOutcomeLambda` for errors occurring at the time of the alarm.
+3. Check for any AWS regional service issues.
+4. Check whether a recent deployment correlates with the start of errors.
+5. Correlate with other AMC alarms — if Token or JourneyOutcome Lambda alarms are also firing, the root cause is likely in the Lambda itself.
+
+### ApiTokenLambdaErrorsAlarm
+
+**What it means:** The Token Lambda function is producing invocation errors (unhandled exceptions or timeouts).
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard.
+2. Check the Token Lambda logs at `/aws/lambda/amc/ApiTokenLambda` for stack traces or timeout messages.
+3. Check Lambda metrics (duration, memory usage, concurrent executions) for resource exhaustion.
+4. Check downstream dependencies (e.g. DynamoDB, KMS) for availability issues.
+5. Check whether a recent deployment correlates with the start of errors.
+
+### ApiTokenLambdaLogErrorAlarm
+
+**What it means:** The Token Lambda is logging ERROR or CRITICAL level messages at an elevated rate.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard.
+2. Check the Token Lambda logs at `/aws/lambda/amc/ApiTokenLambda` — filter for `level = "ERROR"` or `level = "CRITICAL"` to identify the specific error messages.
+3. Check whether errors relate to authorization code validation, client authentication, or token signing.
+4. Check downstream service health (DynamoDB, KMS).
+5. Check whether a recent deployment correlates with the start of errors.
+
+### ApiJourneyOutcomeLambdaErrorsAlarm
+
+**What it means:** The Journey Outcome Lambda function is producing invocation errors (unhandled exceptions or timeouts).
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard.
+2. Check the Journey Outcome Lambda logs at `/aws/lambda/amc/ApiJourneyOutcomeLambda` for stack traces or timeout messages.
+3. Check Lambda metrics (duration, memory usage, concurrent executions) for resource exhaustion.
+4. Check downstream dependencies (e.g. DynamoDB, KMS) for availability issues.
+5. Check whether a recent deployment correlates with the start of errors.
+
+### ApiJourneyOutcomeLambdaLogErrorAlarm
+
+**What it means:** The Journey Outcome Lambda is logging ERROR or CRITICAL level messages at an elevated rate.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard.
+2. Check the Journey Outcome Lambda logs at `/aws/lambda/amc/ApiJourneyOutcomeLambda` — filter for `level = "ERROR"` or `level = "CRITICAL"` to identify the specific error messages.
+3. Check whether errors relate to token validation or journey outcome retrieval.
+4. Check downstream service health (DynamoDB, KMS).
+5. Check whether a recent deployment correlates with the start of errors.
+
+## Testing the Passkey Creation Journey
+
+To verify the API is functioning correctly end-to-end, you can manually test the passkey creation journey:
+
+1. Sign in to Home (account management) at https://home.account.gov.uk
+2. Create a passkey from the account management area.
+
+This exercises the full flow including the OAuth handoff, the frontend journey, and the subsequent `/token` and `/journeyoutcome` requests made by the client.
+
+## Escalation
+
+Contact the Home team via Slack at **[#di-one-login-home-tech](https://gds.slack.com/archives/C011Y5SAY3U)** for resolution.

--- a/runbooks/frontend-alarms-runbook.md
+++ b/runbooks/frontend-alarms-runbook.md
@@ -1,0 +1,87 @@
+# Frontend Alarms Runbook
+
+## Overview
+
+This runbook covers the following second line production alarms for the Account Management Components (AMC) frontend:
+
+- [FrontendApiGateway5XXErrorsAlarm](#frontendapigateway5xxerrorsalarm)
+- [FrontendLambdaErrorsAlarm](#frontendlambdaerrorsalarm)
+- [FrontendLambdaLogErrorAlarm](#frontendlambdalogerroralarm)
+
+## Context
+
+AMC provides reusable account journeys which are initiated from either:
+
+- An **Authentication (sign in/sign up) journey** — handed off from the Auth client
+- **Account management (Home)** — handed off from the Home client
+
+The handoff between the Auth or Home client and AMC is via OAuth (starting at the `/authorize` route).
+
+The frontend Lambda handles all publicly accessible journey routes and the initial `/authorize` route used for the handover to AMC.
+
+Because AMC serves multiple journeys to different clients, the specific cause of an alarm may vary. The investigation steps below are general guidance.
+
+Journeys supported:
+
+- Passkey creation during sign in
+- Passkey creation from account management
+
+## Owning Team
+
+These alarms are owned by the **Home team** in the **Accounts pod**.
+
+Slack channel: **[#di-one-login-home-tech](https://gds.slack.com/archives/C011Y5SAY3U)**
+
+Resolution will likely need to be done by the Home team.
+
+## Alarms
+
+### FrontendApiGateway5XXErrorsAlarm
+
+**What it means:** The Frontend API Gateway is returning more server errors (5XX) than expected.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard for an overview of frontend health.
+2. Check the Frontend Lambda logs at `/aws/lambda/amc/FrontendLambda` for errors occurring at the time of the alarm.
+3. Check for any AWS regional service issues.
+4. Check whether a recent deployment correlates with the start of errors.
+5. Correlate with other AMC alarms — if `FrontendLambdaErrorsAlarm` or `FrontendLambdaLogErrorAlarm` are also firing, the root cause is likely in the Lambda itself.
+
+### FrontendLambdaErrorsAlarm
+
+**What it means:** The Frontend Lambda function is producing invocation errors (unhandled exceptions or timeouts).
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard.
+2. Check the Frontend Lambda logs at `/aws/lambda/amc/FrontendLambda` for stack traces or timeout messages.
+3. Check Lambda metrics (duration, memory usage, concurrent executions) for resource exhaustion.
+4. Check downstream dependencies (e.g. DynamoDB session store, external APIs) for availability issues.
+5. Check whether a recent deployment correlates with the start of errors.
+
+### FrontendLambdaLogErrorAlarm
+
+**What it means:** The Frontend Lambda is logging ERROR or CRITICAL level messages at an elevated rate.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard.
+2. Check the Frontend Lambda logs at `/aws/lambda/amc/FrontendLambda` — filter for `level = "ERROR"` or `level = "CRITICAL"` to identify the specific error messages.
+3. Use the log dimensions (`scope`, `client_id`, `path`) to narrow down which journey and client is affected.
+4. Check whether the errors correlate with a specific route or journey step.
+5. Check downstream service health (Auth, Home, external APIs).
+6. Check whether a recent deployment correlates with the start of errors.
+
+## Testing the Passkey Creation Journey
+
+To verify the frontend is functioning correctly, you can manually test the passkey creation journey:
+
+1. Sign in to Home (account management) at https://home.account.gov.uk
+2. Create a passkey from the account management area.
+
+This exercises the OAuth handoff from Home into AMC and the passkey creation journey routes served by the frontend Lambda.
+
+## Escalation
+
+Contact the Home team via Slack at **[#di-one-login-home-tech](https://gds.slack.com/archives/C011Y5SAY3U)** for resolution.

--- a/runbooks/frontend-alarms-runbook.md
+++ b/runbooks/frontend-alarms-runbook.md
@@ -8,6 +8,12 @@ This runbook covers the following second line production alarms for the Account 
 - [FrontendLambdaErrorsAlarm](#frontendlambdaerrorsalarm)
 - [FrontendLambdaLogErrorAlarm](#frontendlambdalogerroralarm)
 
+## AWS Account
+
+Account: **di-account-components-prod** (494066295151)
+
+Dashboard: [amc-dashboard](https://uk-digital-identity.awsapps.com/start/#/console?account_id=494066295151&role_name=ApprovedServiceSupport&destination=https%3A%2F%2Feu-west-2.console.aws.amazon.com%2Fcloudwatch%2Fhome%3Fregion%3Deu-west-2%23dashboards%2Fdashboard%2Famc-dashboard)
+
 ## Context
 
 AMC provides reusable account journeys which are initiated from either:

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -3138,9 +3138,9 @@ Resources:
               "type": "metric",
               "properties": {
                 "metrics": [
-                  [ { "expression": "SUM(SEARCH('MetricName=\"ResponseCount\"', 'Sum'))", "id": "all_responses", "visible": false } ],
-                  [ { "expression": "SUM(SEARCH('MetricName=\"5XXResponseCount\"', 'Sum'))", "id": "server_error_responses", "visible": false } ],
-                  [ { "expression": "((all_responses - server_error_responses) / all_responses) * 100", "id": "availability", "label": "Availability %" } ]
+                  [ { "expression": "FILL(SUM(SEARCH('MetricName=\"ResponseCount\"', 'Sum')),0)", "id": "all_responses", "visible": false } ],
+                  [ { "expression": "FILL(SUM(SEARCH('MetricName=\"5XXResponseCount\"', 'Sum')),0)", "id": "server_error_responses", "visible": false } ],
+                  [ { "expression": "((all_responses - server_error_responses) / all_responses) * 100", "id": "availability" } ]
                 ],
                 "view": "singleValue",
                 "title": "Availability %",
@@ -3149,7 +3149,25 @@ Resources:
               },
               "width": 6,
               "height": 6
-            },               
+            },  
+            {
+              "type": "log",
+              "properties": {
+                "query": "SOURCE '/aws/lambda/${AWS::StackName}/FrontendLambda' | fields method, path, total | filter message = 'Request' | stats count(*) as total by method, path | sort total desc",
+                "region": "${AWS::Region}",
+                "title": "Frontend requests"
+              },
+              "width": 12
+            },             
+            {
+              "type": "log",
+              "properties": {
+                "query": "SOURCE '/aws/lambda/${AWS::StackName}/FrontendLambda' | fields method, path, statusCode, total | filter message = 'Response' | stats count(*) as total by method, path, statusCode | sort total desc",
+                "region": "${AWS::Region}",
+                "title": "Frontend responses"
+              },
+              "width": 12
+            },                          
             {
               "type": "metric",
               "properties": {
@@ -3331,25 +3349,7 @@ Resources:
               },
               "width": 10,               
               "height": 4
-            },
-            {
-              "type": "log",
-              "properties": {
-                "query": "SOURCE '/aws/lambda/${AWS::StackName}/FrontendLambda' | fields method, path, total | filter message = 'Request' | stats count(*) as total by method, path | sort total desc",
-                "region": "${AWS::Region}",
-                "title": "Frontend requests"
-              },
-              "width": 12
-            },             
-            {
-              "type": "log",
-              "properties": {
-                "query": "SOURCE '/aws/lambda/${AWS::StackName}/FrontendLambda' | fields method, path, statusCode, total | filter message = 'Response' | stats count(*) as total by method, path, statusCode | sort total desc",
-                "region": "${AWS::Region}",
-                "title": "Frontend responses"
-              },
-              "width": 12
-            },   
+            },  
             {
               "type": "text",
               "properties": {

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -1929,6 +1929,60 @@ Resources:
       AlarmActions:
         - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
+  ApiHealthcheckLambda5XXResponseMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiHealthcheckLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" && $.statusCode >= 500 }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/ApiHealthcheckLambda"
+          MetricName: 5XXResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ApiHealthcheckLambdaResponseCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiHealthcheckLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/ApiHealthcheckLambda"
+          MetricName: ResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ApiHealthcheckLambdaAvailabilityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Metrics:
+        - Id: errors
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/ApiHealthcheckLambda"
+              MetricName: 5XXResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/ApiHealthcheckLambda"
+              MetricName: ResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: availability
+          Expression: "1 - (errors / total)"
+          Label: "Availability"
+          ReturnData: true
+      Threshold: 0.999
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+
   ApiTokenLambdaErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -2054,6 +2108,60 @@ Resources:
       AlarmActions:
         - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
+  ApiTokenLambda5XXResponseMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiTokenLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" && $.statusCode >= 500 }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/ApiTokenLambda"
+          MetricName: 5XXResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ApiTokenLambdaResponseCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiTokenLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/ApiTokenLambda"
+          MetricName: ResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ApiTokenLambdaAvailabilityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Metrics:
+        - Id: errors
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/ApiTokenLambda"
+              MetricName: 5XXResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/ApiTokenLambda"
+              MetricName: ResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: availability
+          Expression: "1 - (errors / total)"
+          Label: "Availability"
+          ReturnData: true
+      Threshold: 0.999
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+
   ApiJourneyOutcomeLambdaErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -2175,6 +2283,60 @@ Resources:
       DatapointsToAlarm: 3
       Threshold: 3
       ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+
+  ApiJourneyOutcomeLambda5XXResponseMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiJourneyOutcomeLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" && $.statusCode >= 500 }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/ApiJourneyOutcomeLambda"
+          MetricName: 5XXResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ApiJourneyOutcomeLambdaResponseCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref ApiJourneyOutcomeLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/ApiJourneyOutcomeLambda"
+          MetricName: ResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  ApiJourneyOutcomeLambdaAvailabilityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Metrics:
+        - Id: errors
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/ApiJourneyOutcomeLambda"
+              MetricName: 5XXResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/ApiJourneyOutcomeLambda"
+              MetricName: ResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: availability
+          Expression: "1 - (errors / total)"
+          Label: "Availability"
+          ReturnData: true
+      Threshold: 0.999
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
       TreatMissingData: notBreaching
       AlarmActions:
         - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
@@ -2658,6 +2820,60 @@ Resources:
       AlarmActions:
         - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
+  FrontendLambda5XXResponseMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref FrontendLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" && $.statusCode >= 500 }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/FrontendLambda"
+          MetricName: 5XXResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  FrontendLambdaResponseCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref FrontendLambdaLogGroup
+      FilterPattern: '{ $.message = "Response" }'
+      MetricTransformations:
+        - MetricNamespace: !Sub "${AWS::StackName}/FrontendLambda"
+          MetricName: ResponseCount
+          MetricValue: "1"
+          DefaultValue: 0
+
+  FrontendLambdaAvailabilityAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      Metrics:
+        - Id: errors
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/FrontendLambda"
+              MetricName: 5XXResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: total
+          MetricStat:
+            Metric:
+              Namespace: !Sub "${AWS::StackName}/FrontendLambda"
+              MetricName: ResponseCount
+            Period: 60
+            Stat: Sum
+          ReturnData: false
+        - Id: availability
+          Expression: "1 - (errors / total)"
+          Label: "Availability"
+          ReturnData: true
+      Threshold: 0.999
+      ComparisonOperator: LessThanThreshold
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+
   FrontendLambdaDurationAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -2898,12 +3114,42 @@ Resources:
             {
               "type": "text",
               "properties": {
-                "markdown": "# General",
+                "markdown": "# Requests",
                 "background": "transparent"
               },
               "width": 24,
               "height": 2
-            },          
+            },       
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [ { "expression": "FILL(SUM(SEARCH('MetricName=\"ResponseCount\"', 'Sum')),0)", "id": "all_responses" } ],
+                  [ { "expression": "FILL(SUM(SEARCH('MetricName=\"5XXResponseCount\"', 'Sum')),0)", "id": "server_error_responses" } ]
+                ],
+                "view": "timeSeries",
+                "title": "Availability",
+                "region": "${AWS::Region}"
+              },
+              "width": 18,
+              "height": 6          
+            },
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [ { "expression": "SUM(SEARCH('MetricName=\"ResponseCount\"', 'Sum'))", "id": "all_responses", "visible": false } ],
+                  [ { "expression": "SUM(SEARCH('MetricName=\"5XXResponseCount\"', 'Sum'))", "id": "server_error_responses", "visible": false } ],
+                  [ { "expression": "((all_responses - server_error_responses) / all_responses) * 100", "id": "availability", "label": "Availability %" } ]
+                ],
+                "view": "singleValue",
+                "title": "Availability %",
+                "region": "${AWS::Region}",
+                "setPeriodToTimeRange": true
+              },
+              "width": 6,
+              "height": 6
+            },               
             {
               "type": "metric",
               "properties": {
@@ -3105,6 +3351,41 @@ Resources:
               "width": 12
             },   
             {
+              "type": "text",
+              "properties": {
+                "markdown": "&nbsp;\n# Lambdas",
+                "background": "transparent"
+              },
+              "width": 24,
+              "height": 3
+            },   
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [ { "expression": "FILL(SEARCH('{AWS/Lambda} MetricName=\"ConcurrentExecutions\"', 'Maximum'),0)", "id": "total" } ]
+                ],
+                "view": "timeSeries",
+                "title": "Concurrent lambda executions",
+                "region": "${AWS::Region}"
+              },
+              "width": 12,
+              "height": 4
+            }, 
+            {
+              "type": "metric",
+              "properties": {
+                "metrics": [
+                  [ { "expression": "FILL(SEARCH('{AWS/Lambda} MetricName=\"Invocations\"', 'Sum'),0)", "id": "total" } ]
+                ],
+                "view": "timeSeries",
+                "title": "Lambda invocations",
+                "region": "${AWS::Region}"
+              },
+              "width": 12,
+              "height": 4
+            },                     
+            {
               "type": "metric",
               "properties": {
                 "metrics": [
@@ -3247,33 +3528,7 @@ Resources:
               },
               "width": 6,
               "height": 4
-            },             
-            {
-              "type": "metric",
-              "properties": {
-                "metrics": [
-                  [ { "expression": "FILL(SEARCH('{AWS/Lambda} MetricName=\"ConcurrentExecutions\"', 'Maximum'),0)", "id": "total" } ]
-                ],
-                "view": "timeSeries",
-                "title": "Concurrent lambda executions",
-                "region": "${AWS::Region}"
-              },
-              "width": 12,
-              "height": 4
-            }, 
-            {
-              "type": "metric",
-              "properties": {
-                "metrics": [
-                  [ { "expression": "FILL(SEARCH('{AWS/Lambda} MetricName=\"Invocations\"', 'Sum'),0)", "id": "total" } ]
-                ],
-                "view": "timeSeries",
-                "title": "Lambda invocations",
-                "region": "${AWS::Region}"
-              },
-              "width": 12,
-              "height": 4
-            },                                                                        
+            },                                                                                    
             {
               "type": "text",
               "properties": {

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -1123,10 +1123,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - !If
-          - IsProduction
-          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
-          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   NotificationsServiceLambdaLogWarnByContextMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -1828,6 +1825,7 @@ Resources:
   ApiApiGateway5XXErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC private API Gateway is returning 5XX server errors. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/api-alarms-runbook.md"
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -1878,10 +1876,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - !If
-          - IsProduction
-          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
-          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiHealthcheckLambdaThrottlesAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -1943,10 +1938,7 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - !If
-          - IsProduction
-          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
-          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiHealthcheckLambda5XXResponseMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -2005,6 +1997,7 @@ Resources:
   ApiTokenLambdaErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC token lambda is producing invocation errors. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/api-alarms-runbook.md"
       Namespace: !Sub "${AWS::StackName}/ApiTokenLambda"
       MetricName: Errors
       Dimensions:
@@ -2118,6 +2111,7 @@ Resources:
   ApiTokenLambdaLogErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC token lambda is logging ERROR or CRITICAL level messages at an elevated rate. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/api-alarms-runbook.md"
       Namespace: !Sub "${AWS::StackName}/ApiTokenLambda"
       MetricName: ErrorAndCriticalLogCount
       Statistic: Sum
@@ -2190,6 +2184,7 @@ Resources:
   ApiJourneyOutcomeLambdaErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC journey outcome lambda is producing invocation errors. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/api-alarms-runbook.md"
       Namespace: !Sub "${AWS::StackName}/ApiJourneyOutcomeLambda"
       MetricName: Errors
       Dimensions:
@@ -2303,6 +2298,7 @@ Resources:
   ApiJourneyOutcomeLambdaLogErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC journey outcome lambda is logging ERROR or CRITICAL level messages at an elevated rate. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/api-alarms-runbook.md"
       Namespace: !Sub "${AWS::StackName}/ApiJourneyOutcomeLambda"
       MetricName: ErrorAndCriticalLogCount
       Statistic: Sum
@@ -2709,6 +2705,7 @@ Resources:
   FrontendApiGateway5XXErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC frontend API Gateway is returning 5XX server errors. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/frontend-alarms-runbook.md"
       Namespace: AWS/ApiGateway
       MetricName: 5XXError
       Dimensions:
@@ -2746,6 +2743,7 @@ Resources:
   FrontendLambdaErrorsAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC frontend lambda is producing invocation errors. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/frontend-alarms-runbook.md"
       Namespace: !Sub "${AWS::StackName}/FrontendLambda"
       MetricName: Errors
       Dimensions:
@@ -2847,6 +2845,7 @@ Resources:
   FrontendLambdaLogErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
+      AlarmDescription: "AMC frontend lambda is logging ERROR or CRITICAL level messages at an elevated rate. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/frontend-alarms-runbook.md"
       Namespace: !Sub "${AWS::StackName}/FrontendLambda"
       MetricName: ErrorAndCriticalLogCount
       Statistic: Sum

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -255,6 +255,7 @@ Conditions:
   CanariesEnabled: !Equals
     - !FindInMap [EnvironmentConfiguration, !Ref Environment, UseCanary]
     - true
+  IsProduction: !Equals [!Ref Environment, "production"]
   IsDevEnvironment: !Equals [!Ref Environment, "dev"]
   IsBuildEnvironment: !Equals [!Ref Environment, "build"]
   IsDevOrBuild: !Or [Condition: IsDevEnvironment, Condition: IsBuildEnvironment]
@@ -1122,7 +1123,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   NotificationsServiceLambdaLogWarnByContextMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -1621,6 +1625,8 @@ Resources:
         Alarms:
           - !Ref ApiHealthcheckLambdaErrorsAlarm
           - !Ref ApiHealthcheckLambdaThrottlesAlarm
+          - !Ref ApiHealthcheckLambdaAvailabilityAlarm
+          - !Ref ApiHealthcheckLambdaLogErrorAlarm
       LoggingConfig:
         LogGroup: !Ref ApiHealthcheckLambdaLogGroup
       Handler: healthcheck.handler
@@ -1667,6 +1673,8 @@ Resources:
         Alarms:
           - !Ref ApiTokenLambdaErrorsAlarm
           - !Ref ApiTokenLambdaThrottlesAlarm
+          - !Ref ApiTokenLambdaAvailabilityAlarm
+          - !Ref ApiTokenLambdaLogErrorAlarm
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: 1
       LoggingConfig:
@@ -1741,6 +1749,8 @@ Resources:
         Alarms:
           - !Ref ApiJourneyOutcomeLambdaErrorsAlarm
           - !Ref ApiJourneyOutcomeLambdaThrottlesAlarm
+          - !Ref ApiJourneyOutcomeLambdaAvailabilityAlarm
+          - !Ref ApiJourneyOutcomeLambdaLogErrorAlarm
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: 1
       LoggingConfig:
@@ -1830,7 +1840,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiApiGatewayHighLatencyAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -1865,7 +1878,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiHealthcheckLambdaThrottlesAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -1927,7 +1943,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiHealthcheckLambda5XXResponseMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -1999,7 +2018,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiTokenLambdaThrottlesAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2106,7 +2128,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiTokenLambda5XXResponseMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -2178,7 +2203,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiJourneyOutcomeLambdaThrottlesAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2285,7 +2313,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   ApiJourneyOutcomeLambda5XXResponseMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -2510,6 +2541,8 @@ Resources:
         Alarms:
           - !Ref FrontendLambdaErrorsAlarm
           - !Ref FrontendLambdaThrottlesAlarm
+          - !Ref FrontendLambdaAvailabilityAlarm
+          - !Ref FrontendLambdaLogErrorAlarm
       ProvisionedConcurrencyConfig:
         ProvisionedConcurrentExecutions: 1
       LoggingConfig:
@@ -2688,7 +2721,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   FrontendApiGatewayHighLatencyAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2723,7 +2759,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   FrontendLambdaThrottlesAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -2818,7 +2857,10 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
       AlarmActions:
-        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+        - !If
+          - IsProduction
+          - Fn::ImportValue: !Sub ${AlertsStackName}-SecondLineAlertsTopicArn
+          - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
   FrontendLambda5XXResponseMetricFilter:
     Type: AWS::Logs::MetricFilter

--- a/solutions/infra/build_notifications.tf
+++ b/solutions/infra/build_notifications.tf
@@ -6,7 +6,7 @@ resource "aws_cloudformation_stack" "build_notifications_stack" {
   parameters = {
     BuildNotificationSlackChannelId = var.environment == "production" ? "C0ALMLUAZE3" : "C0AMXCUQEQG"
     CriticalSlackChannelId          = var.environment == "production" ? "C0ALZMSQQTX" : "C0AM3500JUA"
-    SecondLineSlackChannelId        = var.environment == "production" ? "C0AM352UZT4" : "none" # Stack does not allow SecondLineSlackChannelId in non-prod environments
+    SecondLineSlackChannelId        = var.environment == "production" ? "C02HCLREVV5" : "none" # Stack does not allow SecondLineSlackChannelId in non-prod environments
     WarningSlackChannelId           = var.environment == "production" ? "C0AM13L5H7G" : "C0AM13NDKKQ"
     EnrichedNotifications           = "True"
     Environment                     = var.environment


### PR DESCRIPTION
## Summary

Adds availability monitoring (alarms and dashboard widgets) for all application lambdas and updates the second-line Slack channel for production alerts.

## Changes

### Availability alarms (`solutions/app-infra/template.yaml`)

Adds per-lambda availability alarms for **ApiHealthcheckLambda**, **ApiTokenLambda**, **ApiJourneyOutcomeLambda**, and **FrontendLambda**. Each lambda gets:

- A **`5XXResponseCount` metric filter** — counts log entries where `message = "Response"` and `statusCode >= 500`
- A **`ResponseCount` metric filter** — counts all log entries where `message = "Response"`
- An **availability alarm** — uses a math expression (`1 - (5XX / total)`) and triggers when availability drops below 99.9% for 3 consecutive 1-minute evaluation periods

All alarms use `TreatMissingData: notBreaching` (no false alarms during periods of zero traffic) and alert to the `WarningAlertsTopicArn`.

### Dashboard updates (`solutions/app-infra/template.yaml`)

- Renamed the first dashboard section from "General" to "Requests"
- Added a new **"Requests"** section at the top with:
  - A time series widget showing total responses vs 5XX responses across all lambdas
  - A single-value widget showing overall availability percentage for the selected time range
  - Frontend request/response log query widgets (moved here from lower in the dashboard)
- Added a new **"Lambdas"** section header with concurrent executions and invocations widgets (moved from the bottom of the "General" section)

### Slack channel update (`solutions/infra/build_notifications.tf`)

- Updated the production `SecondLineSlackChannelId` from `C0AM352UZT4` to `C02HCLREVV5` (`di-2nd-line`)