### PR TITLE
BAU: Dockerfiles non-root users

### DIFF
--- a/solutions/integration-tests/Dockerfile
+++ b/solutions/integration-tests/Dockerfile
@@ -1,5 +1,3 @@
-#checkov:skip=CKV_DOCKER_3: Not applicable for development image
-
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
@@ -16,10 +14,13 @@ COPY package-lock.json package-lock.json
 COPY .npmrc .npmrc
 COPY .nvmrc .nvmrc
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 RUN npm ci && npm run install-browsers
 
 COPY . .
 
 HEALTHCHECK NONE
+
+USER node
 
 ENTRYPOINT [ "./run-tests.sh" ]

--- a/solutions/localstack/local-kms/Dockerfile
+++ b/solutions/localstack/local-kms/Dockerfile
@@ -3,8 +3,7 @@
 # the tag allows Dependabot to evaluate version constraints
 FROM nsmithuk/local-kms:latest@sha256:e070866476b20973a9e23a9b636204b7a222e4169a6e03198d27b80d47ed28e3
 
-RUN addgroup -S kmsgroup && adduser -S kmsuser -G kmsgroup
-RUN chown -R kmsuser:kmsgroup /data /init
+RUN addgroup -S kmsgroup && adduser -S kmsuser -G kmsgroup && chown -R kmsuser:kmsgroup /data /init
 
 USER kmsuser
 

--- a/solutions/localstack/local-kms/Dockerfile
+++ b/solutions/localstack/local-kms/Dockerfile
@@ -1,8 +1,11 @@
-#checkov:skip=CKV_DOCKER_3: Not applicable for development image
-
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
 FROM nsmithuk/local-kms:latest@sha256:e070866476b20973a9e23a9b636204b7a222e4169a6e03198d27b80d47ed28e3
+
+RUN addgroup -S kmsgroup && adduser -S kmsuser -G kmsgroup
+RUN chown -R kmsuser:kmsgroup /data /init
+
+USER kmsuser
 
 HEALTHCHECK NONE

--- a/solutions/localstack/localstack/Dockerfile
+++ b/solutions/localstack/localstack/Dockerfile
@@ -1,8 +1,8 @@
-#checkov:skip=CKV_DOCKER_3: Not applicable for development image
-
 # Despite what SonarQube says both the tag and sha digest are needed:
 # the digest pins the exact image for reproducibility,
 # the tag allows Dependabot to evaluate version constraints
 FROM localstack/localstack:4.12.0@sha256:0df3a97da57de03a588c05d9b8f390f15c7033fc7c4512f94619d344bc3cd317
+
+USER localstack
 
 HEALTHCHECK NONE


### PR DESCRIPTION
Update the various development Dockerfiles to not run using the root user. This is to address ITHC findings.