### PR TITLE
OLH-4370: cache encryption

### DIFF
--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -1460,6 +1460,7 @@ Resources:
         DestinationArn: !GetAtt ApiApiGatewayAccessLogGroup.Arn
       MethodSettings:
         - MetricsEnabled: true
+          CacheDataEncrypted: true
           ResourcePath: /*
           HttpMethod: "*"
       Policy:
@@ -2509,6 +2510,7 @@ Resources:
         DestinationArn: !GetAtt FrontendApiGatewayAccessLogGroup.Arn
       MethodSettings:
         - MetricsEnabled: true
+          CacheDataEncrypted: true
           ResourcePath: /*
           HttpMethod: "*"
       Tags:
@@ -3057,6 +3059,7 @@ Resources:
         DestinationArn: !GetAtt StubsApiGatewayAccessLogGroup.Arn
       MethodSettings:
         - MetricsEnabled: true
+          CacheDataEncrypted: true
           ResourcePath: /*
           HttpMethod: "*"
       Tags:


### PR DESCRIPTION
Enable API Gateway cache encryption. We don't currently cache any responses but this ensures that if we do in future then the cache will be encrypted.