### PR TITLE
OLH-4367: send X-Permitted-Cross-Domain-Policies: none; header

### DIFF
--- a/solutions/frontend/src/index.ts
+++ b/solutions/frontend/src/index.ts
@@ -266,7 +266,9 @@ export const initFrontend = async function () {
       includeSubDomains: true,
     },
     referrerPolicy: false,
-    permittedCrossDomainPolicies: false,
+    permittedCrossDomainPolicies: {
+      permittedPolicies: "none",
+    },
   });
 
   fastify.register(async (fastify) => {


### PR DESCRIPTION
Setting X-Permitted-Cross-Domain-Policies: none tells Adobe Flash and Acrobat (and similar cross-domain-capable clients) that they are not allowed to load any data from your domain, even if a `crossdomain.xml` file is present.

Previously, with `permittedCrossDomainPolicies: false`, helmet was not sending this header at all — meaning there was no explicit instruction to those clients, and they could potentially respect a `crossdomain.xml` file if one existed.

In practice, this is a defence-in-depth measure. Flash is effectively dead, but the header is still recommended as a security best practice to prevent any legacy or niche cross-domain policy abuse.