### PR TITLE
BAU: improve API client logging

### DIFF
--- a/solutions/frontend/src/utils/accountDataApiClient.test.ts
+++ b/solutions/frontend/src/utils/accountDataApiClient.test.ts
@@ -18,7 +18,11 @@ vi.mock(import("./jsonApiClient.js"), () => ({
 
     static processResponse = vi.fn();
     static undefinedSchema = {};
-    static unknownError = { success: false, error: "UnknownError" };
+    static unknownError = {
+      success: false,
+      error: "UnknownError",
+      rawResponse: undefined,
+    };
   },
 }));
 
@@ -93,12 +97,18 @@ describe("accountDataApiClient", () => {
 
     it("should return unknown error when fetch throws", async () => {
       const client = new AccountDataApiClient(mockAccessToken, mockEvent);
+      const error = new Error("Network error");
 
-      mockThisFetch.mockRejectedValueOnce(new Error("Network error"));
+      mockThisFetch.mockRejectedValueOnce(error);
 
       const result = await client.getPasskeys("test-public-subject-id");
 
-      expect(result).toStrictEqual({ success: false, error: "UnknownError" });
+      expect(result).toStrictEqual({
+        success: false,
+        error: "UnknownError",
+        rawResponse: undefined,
+        errorDetails: error,
+      });
     });
   });
 
@@ -138,8 +148,9 @@ describe("accountDataApiClient", () => {
 
     it("should return unknown error when fetch throws", async () => {
       const client = new AccountDataApiClient(mockAccessToken, mockEvent);
+      const error = new Error("Network error");
 
-      mockThisFetch.mockRejectedValueOnce(new Error("Network error"));
+      mockThisFetch.mockRejectedValueOnce(error);
 
       const result = await client.createPasskey("test-public-subject-id", {
         credential: "test-credential",
@@ -154,7 +165,12 @@ describe("accountDataApiClient", () => {
         algorithm: -7,
       });
 
-      expect(result).toStrictEqual({ success: false, error: "UnknownError" });
+      expect(result).toStrictEqual({
+        success: false,
+        error: "UnknownError",
+        rawResponse: undefined,
+        errorDetails: error,
+      });
     });
   });
 });

--- a/solutions/frontend/src/utils/accountDataApiClient.ts
+++ b/solutions/frontend/src/utils/accountDataApiClient.ts
@@ -60,8 +60,11 @@ export class AccountDataApiClient extends JsonApiClient {
           }),
           errorsCodesMap,
         );
-      } catch {
-        return AccountDataApiClient.unknownError;
+      } catch (error) {
+        return {
+          ...AccountDataApiClient.unknownError,
+          errorDetails: error,
+        };
       }
     });
   }
@@ -96,8 +99,11 @@ export class AccountDataApiClient extends JsonApiClient {
           AccountDataApiClient.undefinedSchema,
           errorsCodesMap,
         );
-      } catch {
-        return AccountDataApiClient.unknownError;
+      } catch (error) {
+        return {
+          ...AccountDataApiClient.unknownError,
+          errorDetails: error,
+        };
       }
     });
   }

--- a/solutions/frontend/src/utils/accountManagementApiClient.test.ts
+++ b/solutions/frontend/src/utils/accountManagementApiClient.test.ts
@@ -18,7 +18,11 @@ vi.mock(import("./jsonApiClient.js"), () => ({
 
     static processResponse = vi.fn();
     static undefinedSchema = {};
-    static unknownError = { success: false, error: "UnknownError" };
+    static unknownError = {
+      success: false,
+      error: "UnknownError",
+      rawResponse: undefined,
+    };
   },
 }));
 
@@ -79,12 +83,18 @@ describe("accountManagementApiClient", () => {
 
     it("should return unknown error when fetch throws", async () => {
       const client = new AccountManagementApiClient(mockAccessToken, mockEvent);
+      const error = new Error("Network error");
 
-      mockThisFetch.mockRejectedValueOnce(new Error("Network error"));
+      mockThisFetch.mockRejectedValueOnce(error);
 
       const result = await client.sendOtpChallenge("test-public-subject-id");
 
-      expect(result).toStrictEqual({ success: false, error: "UnknownError" });
+      expect(result).toStrictEqual({
+        success: false,
+        error: "UnknownError",
+        rawResponse: undefined,
+        errorDetails: error,
+      });
     });
   });
 
@@ -116,15 +126,21 @@ describe("accountManagementApiClient", () => {
 
     it("should return unknown error when fetch throws", async () => {
       const client = new AccountManagementApiClient(mockAccessToken, mockEvent);
+      const error = new Error("Network error");
 
-      mockThisFetch.mockRejectedValueOnce(new Error("Network error"));
+      mockThisFetch.mockRejectedValueOnce(error);
 
       const result = await client.authenticate(
         "test@example.com",
         "password123",
       );
 
-      expect(result).toStrictEqual({ success: false, error: "UnknownError" });
+      expect(result).toStrictEqual({
+        success: false,
+        error: "UnknownError",
+        rawResponse: undefined,
+        errorDetails: error,
+      });
     });
   });
 
@@ -154,12 +170,18 @@ describe("accountManagementApiClient", () => {
 
     it("should return unknown error when fetch throws", async () => {
       const client = new AccountManagementApiClient(mockAccessToken, mockEvent);
+      const error = new Error("Network error");
 
-      mockThisFetch.mockRejectedValueOnce(new Error("Network error"));
+      mockThisFetch.mockRejectedValueOnce(error);
 
       const result = await client.deleteAccount("test@example.com");
 
-      expect(result).toStrictEqual({ success: false, error: "UnknownError" });
+      expect(result).toStrictEqual({
+        success: false,
+        error: "UnknownError",
+        rawResponse: undefined,
+        errorDetails: error,
+      });
     });
   });
 
@@ -191,15 +213,21 @@ describe("accountManagementApiClient", () => {
 
     it("should return unknown error when fetch throws", async () => {
       const client = new AccountManagementApiClient(mockAccessToken, mockEvent);
+      const error = new Error("Network error");
 
-      mockThisFetch.mockRejectedValueOnce(new Error("Network error"));
+      mockThisFetch.mockRejectedValueOnce(error);
 
       const result = await client.verifyOtpChallenge(
         "test-public-subject-id",
         "123456",
       );
 
-      expect(result).toStrictEqual({ success: false, error: "UnknownError" });
+      expect(result).toStrictEqual({
+        success: false,
+        error: "UnknownError",
+        rawResponse: undefined,
+        errorDetails: error,
+      });
     });
   });
 });

--- a/solutions/frontend/src/utils/accountManagementApiClient.ts
+++ b/solutions/frontend/src/utils/accountManagementApiClient.ts
@@ -49,8 +49,11 @@ export class AccountManagementApiClient extends JsonApiClient {
           AccountManagementApiClient.undefinedSchema,
           errorsCodesMap,
         );
-      } catch {
-        return AccountManagementApiClient.unknownError;
+      } catch (error) {
+        return {
+          ...AccountManagementApiClient.unknownError,
+          errorDetails: error,
+        };
       }
     });
   }
@@ -76,8 +79,11 @@ export class AccountManagementApiClient extends JsonApiClient {
           AccountManagementApiClient.undefinedSchema,
           errorsCodesMap,
         );
-      } catch {
-        return AccountManagementApiClient.unknownError;
+      } catch (error) {
+        return {
+          ...AccountManagementApiClient.unknownError,
+          errorDetails: error,
+        };
       }
     });
   }
@@ -109,8 +115,11 @@ export class AccountManagementApiClient extends JsonApiClient {
           AccountManagementApiClient.undefinedSchema,
           errorsCodesMap,
         );
-      } catch {
-        return AccountManagementApiClient.unknownError;
+      } catch (error) {
+        return {
+          ...AccountManagementApiClient.unknownError,
+          errorDetails: error,
+        };
       }
     });
   }
@@ -141,8 +150,11 @@ export class AccountManagementApiClient extends JsonApiClient {
           AccountManagementApiClient.undefinedSchema,
           errorsCodesMap,
         );
-      } catch {
-        return AccountManagementApiClient.unknownError;
+      } catch (error) {
+        return {
+          ...AccountManagementApiClient.unknownError,
+          errorDetails: error,
+        };
       }
     });
   }

--- a/solutions/frontend/src/utils/jsonApiClient.test.ts
+++ b/solutions/frontend/src/utils/jsonApiClient.test.ts
@@ -25,10 +25,7 @@ class TestJsonApiClient extends JsonApiClient {
     return this.fetch;
   }
 
-  public testLogOnError<T extends { success: boolean; error?: string }>(
-    methodName: string,
-    fn: () => Promise<T>,
-  ): Promise<T> {
+  public testLogOnError(methodName: string, fn: () => Promise<any>) {
     return this.logOnError(methodName, fn);
   }
 
@@ -238,6 +235,8 @@ describe("jsonApiClient", () => {
         message: "TestService",
         error: "TestError",
         errorDetails: { foo: "bar" },
+        responseStatusCode: undefined,
+        responseStatus: undefined,
       });
     });
 
@@ -252,6 +251,38 @@ describe("jsonApiClient", () => {
         message: "TestService",
         error: undefined,
         errorDetails: undefined,
+        responseStatusCode: undefined,
+        responseStatus: undefined,
+      });
+    });
+
+    it("should log response status when rawResponse is present", async () => {
+      const mockResponse = {
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response;
+      const errorFn = vi.fn().mockResolvedValue({
+        success: false,
+        error: "ServerError",
+        errorDetails: undefined,
+        rawResponse: mockResponse,
+      });
+
+      const result = await client.testLogOnError("testMethod", errorFn);
+
+      expect(result).toStrictEqual({
+        success: false,
+        error: "ServerError",
+        errorDetails: undefined,
+        rawResponse: mockResponse,
+      });
+      expect(mockLogger.error).toHaveBeenCalledWith({
+        method: "testMethod",
+        message: "TestService",
+        error: "ServerError",
+        errorDetails: undefined,
+        responseStatusCode: 500,
+        responseStatus: "Internal Server Error",
       });
     });
   });

--- a/solutions/frontend/src/utils/jsonApiClient.ts
+++ b/solutions/frontend/src/utils/jsonApiClient.ts
@@ -3,6 +3,26 @@ import { logger } from "../../../commons/utils/logger/index.js";
 import { getPropsFromAPIGatewayEvent } from "../../../commons/utils/getPropsFromAPIGatewayEvent/index.js";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
+type ProcessResponseError =
+  | "ErrorParsingResponseBodyJson"
+  | "ErrorValidatingResponseBody"
+  | "ErrorParsingErrorResponseBodyJson"
+  | "ErrorValidatingErrorResponseBody"
+  | "UnknownErrorResponse";
+
+type Result<TSuccess, TErrorMap extends Record<string, string>> =
+  | {
+      readonly success: true;
+      readonly result: TSuccess;
+      readonly rawResponse: Response;
+    }
+  | {
+      readonly success: false;
+      readonly error: TErrorMap[keyof TErrorMap] | ProcessResponseError;
+      readonly errorDetails: unknown;
+      readonly rawResponse: Response;
+    };
+
 export abstract class JsonApiClient {
   private readonly errorScope: string;
   protected static readonly unknownError = {
@@ -58,8 +78,18 @@ export abstract class JsonApiClient {
   }
 
   protected async logOnError<
-    T extends { success: boolean; error?: string; errorDetails?: unknown },
-  >(methodName: string, fn: () => Promise<T>): Promise<T> {
+    TSuccess,
+    const TErrorMap extends Record<string, string>,
+  >(
+    methodName: string,
+    fn: () => Promise<
+      | Result<TSuccess, TErrorMap>
+      | (Omit<
+          Extract<Result<TSuccess, TErrorMap>, { success: false }>,
+          "rawResponse"
+        > & { readonly rawResponse?: Response | undefined })
+    >,
+  ) {
     const result = await fn();
     if (!result.success) {
       logger.error({
@@ -67,6 +97,8 @@ export abstract class JsonApiClient {
         message: this.errorScope,
         error: result.error,
         errorDetails: result.errorDetails,
+        responseStatusCode: result.rawResponse?.status,
+        responseStatus: result.rawResponse?.statusText,
       });
     }
     return result;
@@ -79,25 +111,7 @@ export abstract class JsonApiClient {
     response: Response,
     successResponseBodySchema: v.GenericSchema<unknown, TSuccess>,
     errorCodesMap: TErrorMap,
-  ): Promise<
-    | {
-        readonly success: true;
-        readonly result: TSuccess;
-        readonly rawResponse: Response;
-      }
-    | {
-        readonly success: false;
-        readonly error:
-          | TErrorMap[keyof TErrorMap]
-          | "ErrorParsingResponseBodyJson"
-          | "ErrorValidatingResponseBody"
-          | "ErrorParsingErrorResponseBodyJson"
-          | "ErrorValidatingErrorResponseBody"
-          | "UnknownErrorResponse";
-        readonly errorDetails: unknown;
-        readonly rawResponse: Response;
-      }
-  > {
+  ): Promise<Result<TSuccess, TErrorMap>> {
     if (response.ok) {
       if (
         // @ts-expect-error


### PR DESCRIPTION
## Improve error observability in API clients

Catch blocks in API client methods previously discarded exceptions silently. Now the caught error is preserved as `errorDetails` in the result, and `logOnError` additionally logs `responseStatusCode` and `responseStatus` when a response is available.

### Changes

- **jsonApiClient.ts**: Added `ProcessResponseError` and `Result` type aliases to reduce repetition. `logOnError` now logs `responseStatusCode` and `responseStatus` from `rawResponse`.
- **accountDataApiClient.ts** / **accountManagementApiClient.ts**: All catch blocks now capture the error and include it as `errorDetails`.
- **Test files**: Updated assertions to expect `errorDetails` and the new log fields. Added test for logging response status.