### PR TITLE
BAU: handle error response with no code

### DIFF
--- a/solutions/frontend/src/utils/jsonApiClient.test.ts
+++ b/solutions/frontend/src/utils/jsonApiClient.test.ts
@@ -603,6 +603,32 @@ describe("jsonApiClient", () => {
           },
         });
       });
+
+      it("should handle error response with no code field", async () => {
+        const errorResponse = { message: "Something went wrong" };
+        const response = {
+          ok: false,
+          json: vi.fn().mockResolvedValue(errorResponse),
+        } as unknown as Response;
+        const schema = v.string();
+        const errorMap = { "400": "BadRequest" };
+
+        const result = await TestJsonApiClient.testProcessResponse(
+          response,
+          schema,
+          errorMap,
+        );
+
+        expect(result).toStrictEqual({
+          success: false,
+          error: "UnknownErrorResponse",
+          rawResponse: response,
+          errorDetails: {
+            code: undefined,
+            message: "Something went wrong",
+          },
+        });
+      });
     });
 
     describe("edge cases", () => {

--- a/solutions/frontend/src/utils/jsonApiClient.ts
+++ b/solutions/frontend/src/utils/jsonApiClient.ts
@@ -162,7 +162,7 @@ export abstract class JsonApiClient {
     }
 
     const errorResponseBodySchema = v.object({
-      code: v.number(),
+      code: v.optional(v.number()),
       message: v.string(),
     });
 
@@ -198,7 +198,10 @@ export abstract class JsonApiClient {
       };
     }
 
-    if (!Object.keys(errorCodesMap).includes(body.output.code.toString())) {
+    if (
+      body.output.code === undefined ||
+      !Object.keys(errorCodesMap).includes(body.output.code.toString())
+    ) {
       return {
         success: false,
         error: "UnknownErrorResponse",


### PR DESCRIPTION
Updates the API client class to more gracefully handle errors without a code