### PR TITLE
OLH-4437: send passkey enrolment failed event in all scenarios

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -534,6 +534,11 @@ describe("passkey-create handlers", () => {
         expect(
           mockSendPasskeyRegistrationFailedAuditEvent,
         ).toHaveBeenCalledTimes(1);
+        expect(mockSendPasskeyEnrolmentFailedAuditEvent).toHaveBeenCalledWith(
+          mockRequest,
+          mockReply,
+          { challenge: "test-challenge" },
+        );
       });
     });
 
@@ -1003,6 +1008,11 @@ describe("passkey-create handlers", () => {
         expect(
           mockSendPasskeyRegistrationFailedAuditEvent,
         ).toHaveBeenCalledTimes(1);
+        expect(mockSendPasskeyEnrolmentFailedAuditEvent).toHaveBeenCalledWith(
+          mockRequest,
+          mockReply,
+          { challenge: "test-challenge" },
+        );
       });
 
       it("should throw when journey state is missing", async () => {

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -208,6 +208,13 @@ export async function postHandler(
   request: FastifyRequest,
   reply: FastifyReply,
 ) {
+  assert.ok(reply.journeyStates?.["passkey-create"]);
+
+  const registrationOptions =
+    reply.journeyStates["passkey-create"].getSnapshot().context
+      .registrationOptions;
+  assert.ok(registrationOptions);
+
   const stringsSuffix = getStringsSuffix(reply);
 
   const bodyParseResult = v.safeParse(postBodySchema, request.body);
@@ -226,6 +233,11 @@ export async function postHandler(
     };
 
     await sendPasskeyRegistrationFailedAuditEvent(request, reply);
+    await sendPasskeyEnrolmentFailedAuditEvent(
+      request,
+      reply,
+      registrationOptions,
+    );
 
     await render(request, reply, {
       showErrorUi: true,
@@ -290,6 +302,11 @@ export async function postHandler(
     };
 
     await sendPasskeyRegistrationFailedAuditEvent(request, reply, reason);
+    await sendPasskeyEnrolmentFailedAuditEvent(
+      request,
+      reply,
+      registrationOptions,
+    );
 
     await render(request, reply, {
       showErrorUi: true,
@@ -299,12 +316,6 @@ export async function postHandler(
 
   assert.ok(process.env["PASSKEYS_RP_ID"]);
   assert.ok(process.env["PASSKEYS_EXPECTED_ORIGIN"]);
-  assert.ok(reply.journeyStates?.["passkey-create"]);
-
-  const registrationOptions =
-    reply.journeyStates["passkey-create"].getSnapshot().context
-      .registrationOptions;
-  assert.ok(registrationOptions);
 
   await sendPasskeyRegistrationSuccessfulAuditEvent(
     request,

--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
@@ -547,6 +547,38 @@ describe("passkey-create audit events", () => {
       );
     });
 
+    it("excludes passkey_enrolment_failure_reason when registrationResponse is undefined", async () => {
+      await sendPasskeyEnrolmentFailedAuditEvent(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+        registrationOptions as PublicKeyCredentialCreationOptionsJSON,
+      );
+
+      const eventPayload = mockCreateEvent.mock.calls[0]?.[1];
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(eventPayload.extensions.passkey).not.toHaveProperty(
+        "passkey_enrolment_failure_reason",
+      );
+    });
+
+    it("excludes passkey_enrolment_failure_reason when reason is undefined", async () => {
+      await sendPasskeyEnrolmentFailedAuditEvent(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+        registrationOptions as PublicKeyCredentialCreationOptionsJSON,
+        registrationResponse,
+        undefined,
+      );
+
+      const eventPayload = mockCreateEvent.mock.calls[0]?.[1];
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(eventPayload.extensions.passkey).not.toHaveProperty(
+        "passkey_enrolment_failure_reason",
+      );
+    });
+
     it("maps empty excludeCredentials to empty array", async () => {
       await sendPasskeyEnrolmentFailedAuditEvent(
         mockRequest as FastifyRequest,

--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
@@ -237,10 +237,10 @@ export const sendPasskeyEnrolmentFailedAuditEvent = async (
   request: FastifyRequest,
   reply: FastifyReply,
   registrationOptions: PublicKeyCredentialCreationOptionsJSON,
-  registrationResponse: InferOutput<
+  registrationResponse?: InferOutput<
     typeof postBodySchema
   >["registrationResponse"],
-  reason: string,
+  reason?: string,
 ) => {
   const base = getBaseEventProps(request, reply);
   if (!base) return;
@@ -261,7 +261,10 @@ export const sendPasskeyEnrolmentFailedAuditEvent = async (
         }),
         passkey: {
           ...enrolment.extensions,
-          passkey_enrolment_failure_reason: reason,
+          ...(registrationResponse !== undefined &&
+            reason !== undefined && {
+              passkey_enrolment_failure_reason: reason,
+            }),
         },
       },
       restricted: {


### PR DESCRIPTION
The audit event `AMC_PASSKEY_ENROLMENT_FAILED` is not being sent in cases where `AMC_PASSKEY_REGISTRATION_FAILED` is sent. This fixes that so it sent in those scenarios too.