### PR TITLE
BAU: rename state machine event

### DIFF
--- a/solutions/frontend/open-api-spec.yaml
+++ b/solutions/frontend/open-api-spec.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.3
 
 info:
   title: Account Management Components OAuth Provider Public API
-  version: 0.0.15
+  version: 0.0.16
   description: |
     OAuth 2.0 provider endpoints, including:
     - GET /authorize
@@ -179,6 +179,7 @@ components:
         - `jti` (string): JWT ID, must be unique
         - `account_management_api_access_token` (string, optional): Access token for account management API
         - `account_data_api_access_token` (string, optional): Access token for account data API
+        - `stubs_account_interventions_service_api_access_token` (string, optional): Access token for stubbed account interventions API, used to determine which canned response to return. Only needed when calling the stubbed account interventions API instead of the real one.
         - `sub` (string): Internal pairwise identifier
         - `public_sub` (string): Public subject identifier
         - `email` (string): User email address

--- a/solutions/frontend/src/journeys/account-delete/handlers/verifyEmailAddress.test.ts
+++ b/solutions/frontend/src/journeys/account-delete/handlers/verifyEmailAddress.test.ts
@@ -105,7 +105,7 @@ describe("verifyEmailAddress handlers", () => {
       expect(
         mockReply.journeyStates?.["account-delete"]?.send,
       ).toHaveBeenCalledWith({
-        type: "notAuthenticated",
+        type: "emailVerified",
       });
       expect(mockReply.redirect).toHaveBeenCalledWith(
         "/reset-delete/enter-password",

--- a/solutions/frontend/src/journeys/account-delete/handlers/verifyEmailAddress.ts
+++ b/solutions/frontend/src/journeys/account-delete/handlers/verifyEmailAddress.ts
@@ -117,7 +117,7 @@ export async function verifyEmailAddressPostHandler(
   }
 
   reply.journeyStates["account-delete"].send({
-    type: "notAuthenticated",
+    type: "emailVerified",
   });
 
   reply.redirect(

--- a/solutions/frontend/src/journeys/utils/stateMachines/account-delete.ts
+++ b/solutions/frontend/src/journeys/utils/stateMachines/account-delete.ts
@@ -14,7 +14,7 @@ export enum AcountDeleteJourneyState {
 export const accountDeleteStateMachine = createJourneyStateMachine<
   MachineContext,
   | {
-      type: "notAuthenticated";
+      type: "emailVerified";
     }
   | {
       type: "lockedOutSecurityCodeEnteredTooManyTimes";
@@ -33,7 +33,7 @@ export const accountDeleteStateMachine = createJourneyStateMachine<
   states: {
     [AcountDeleteJourneyState.emailNotVerified]: {
       on: {
-        notAuthenticated: AcountDeleteJourneyState.notAuthenticated,
+        emailVerified: AcountDeleteJourneyState.notAuthenticated,
         lockedOutSecurityCodeEnteredTooManyTimes:
           AcountDeleteJourneyState.lockedOutSecurityCodeEnteredTooManyTimes,
         lockedOutSecurityCodeRequestedTooManyTimes:


### PR DESCRIPTION
Renames the `notAuthenticated` event on the `account-delete` state machine to `emailVerified` which more accurately represents when this event is sent