### PR TITLE
BAU: add dependabot dependency grouping

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -139,6 +139,11 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "gitsubmodule" # zizmor: ignore[dependabot-cooldown]
     directories:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -168,3 +168,8 @@ updates:
     labels:
       - dependabot
       - dependencies
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -90,6 +90,11 @@ updates:
       - dependencies
     commit-message:
       prefix: BAU
+    groups:
+      pre-commit-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "terraform"
     directories:


### PR DESCRIPTION
Add minor/patch grouping to dependabot ecosystems that were previously ungrouped, reducing the number of individual PRs created per cycle.

Groups added:
- pip: `pip-minor-patch`
- pre-commit: `pre-commit-minor-patch`
- docker: `docker-minor-patch`

Major version bumps are excluded from all groups and will continue to get individual PRs as they are more likely to contain breaking changes.