### PR TITLE
OLH-4448: explicit action start and end times

### DIFF
--- a/solutions/frontend/src/journeys/account-delete/handlers/confirm.test.ts
+++ b/solutions/frontend/src/journeys/account-delete/handlers/confirm.test.ts
@@ -80,7 +80,7 @@ describe("confirm handlers", () => {
     it("should delete account and complete journey when successful", async () => {
       // @ts-expect-error
       mockRequest.session.journeyActions = [
-        { action: "temp-account-delete-action" },
+        { action: "temp-account-delete-action", startedAt: 123456 },
       ];
       mockDeleteAccount.mockResolvedValue({ success: true });
       mockCompleteJourney.mockResolvedValue(mockReply);

--- a/solutions/frontend/src/journeys/utils/completeJourney.test.ts
+++ b/solutions/frontend/src/journeys/utils/completeJourney.test.ts
@@ -104,7 +104,8 @@ describe("completeJourney", () => {
         action: "testing-journey-action",
         success: true,
         details: {},
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
 
@@ -137,7 +138,8 @@ describe("completeJourney", () => {
                   action: "testing-journey-action",
                   success: true,
                   details: {},
-                  timestamp: 1000,
+                  startedAt: 1000,
+                  completedAt: 2000,
                 },
               ],
               expires: Math.floor(mockNow / 1000) + 600,
@@ -187,7 +189,8 @@ describe("completeJourney", () => {
         action: "testing-journey-action",
         success: true,
         details: {},
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
 
@@ -220,7 +223,8 @@ describe("completeJourney", () => {
           description: "UserSignedOut",
           destroySession: true,
         },
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
 
@@ -259,7 +263,8 @@ describe("completeJourney", () => {
           description: "UserSignedOut",
           destroySession: true,
         },
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
 
@@ -288,7 +293,8 @@ describe("completeJourney", () => {
           },
         },
         error: undefined,
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ]);
   });
@@ -309,7 +315,8 @@ describe("completeJourney", () => {
           description: "UserAbortedJourney",
           destroySession: false,
         },
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
 
@@ -354,7 +361,7 @@ describe("completeJourney", () => {
     const mockAppConfig = { auth_code_ttl: 300, journey_outcome_ttl: 600 };
 
     mockRequest.session.journeyActions = [
-      { action: "temp-account-delete-action" },
+      { action: "temp-account-delete-action", startedAt: 1000 },
     ];
 
     mockRandomBytes
@@ -428,7 +435,8 @@ describe("completeJourney", () => {
         action: "testing-journey-action",
         success: true,
         details: {},
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
     (mockRequest as unknown as { awsLambda: unknown }).awsLambda = {
@@ -489,7 +497,8 @@ describe("completeJourney", () => {
           description: "UserSignedOut",
           destroySession: true,
         },
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
     (mockRequest as unknown as { awsLambda: unknown }).awsLambda = {
@@ -545,7 +554,8 @@ describe("completeJourney", () => {
           description: "UserSignedOut",
           destroySession: true,
         },
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
       {
         action: "passkey-create",
@@ -555,7 +565,8 @@ describe("completeJourney", () => {
           description: "UserAbortedJourney",
           destroySession: false,
         },
-        timestamp: 2000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
     (mockRequest as unknown as { awsLambda: unknown }).awsLambda = {
@@ -610,7 +621,8 @@ describe("completeJourney", () => {
         action: "testing-journey-action",
         success: true,
         details: {},
-        timestamp: 1000,
+        startedAt: 1000,
+        completedAt: 2000,
       },
     ];
 

--- a/solutions/frontend/src/journeys/utils/journeyActions.test.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.test.ts
@@ -46,13 +46,13 @@ describe("journeyActions", () => {
       );
 
       expect(mockRequest.session.journeyActions).toStrictEqual([
-        { action: "temp-account-delete-action" },
+        { action: "temp-account-delete-action", startedAt: expect.any(Number) },
       ]);
     });
 
     it("should push the action to existing journeyActions", async () => {
       mockRequest.session.journeyActions = [
-        { action: "temp-account-delete-action" },
+        { action: "temp-account-delete-action", startedAt: 500 },
       ] as FastifySessionObject["journeyActions"];
 
       await startJourneyAction<"passkeyCreate">(
@@ -62,14 +62,14 @@ describe("journeyActions", () => {
       );
 
       expect(mockRequest.session.journeyActions).toStrictEqual([
-        { action: "temp-account-delete-action" },
-        { action: "passkey-create" },
+        { action: "temp-account-delete-action", startedAt: 500 },
+        { action: "passkey-create", startedAt: expect.any(Number) },
       ]);
     });
 
     it("should not push a duplicate when the action is already in progress", async () => {
       mockRequest.session.journeyActions = [
-        { action: "temp-account-delete-action" },
+        { action: "temp-account-delete-action", startedAt: 500 },
       ] as FastifySessionObject["journeyActions"];
 
       await startJourneyAction<"tempAccountDeleteAction">(
@@ -79,7 +79,7 @@ describe("journeyActions", () => {
       );
 
       expect(mockRequest.session.journeyActions).toStrictEqual([
-        { action: "temp-account-delete-action" },
+        { action: "temp-account-delete-action", startedAt: 500 },
       ]);
     });
 
@@ -167,9 +167,9 @@ describe("journeyActions", () => {
       );
     });
 
-    it("should replace the action with a successful completed action and add a timestamp", async () => {
+    it("should complete the action successfully with startedAt preserved and completedAt set", async () => {
       mockRequest.session.journeyActions = [
-        { action: "temp-account-delete-action" },
+        { action: "temp-account-delete-action", startedAt: 500 },
       ] as FastifySessionObject["journeyActions"];
 
       await completeJourneyActionSuccessfully<"tempAccountDeleteAction">(
@@ -186,7 +186,8 @@ describe("journeyActions", () => {
           action: "temp-account-delete-action",
           success: true,
           details: {},
-          timestamp: 1000,
+          startedAt: 500,
+          completedAt: 1000,
         },
       ]);
     });
@@ -200,7 +201,9 @@ describe("journeyActions", () => {
           email: "test@example.com",
           public_sub: "public-sub-123",
         },
-        journeyActions: [{ action: "temp-account-delete-action" }],
+        journeyActions: [
+          { action: "temp-account-delete-action", startedAt: 500 },
+        ],
       } as unknown as typeof mockRequest.session;
       mockGetCommonAuditEventProps.mockReturnValue({
         user: { session_id: "session-123" },
@@ -276,9 +279,9 @@ describe("journeyActions", () => {
       );
     });
 
-    it("should replace the action with a failed completed action and add a timestamp", async () => {
+    it("should complete the action unsuccessfully with startedAt preserved and completedAt set", async () => {
       mockRequest.session.journeyActions = [
-        { action: "temp-account-delete-action" },
+        { action: "temp-account-delete-action", startedAt: 500 },
       ] as FastifySessionObject["journeyActions"];
 
       await completeJourneyActionUnsuccessfully(
@@ -303,7 +306,8 @@ describe("journeyActions", () => {
             description: "UserSignedOut",
             destroySession: true,
           },
-          timestamp: 2000,
+          startedAt: 500,
+          completedAt: 2000,
         },
       ]);
     });
@@ -317,7 +321,9 @@ describe("journeyActions", () => {
           email: "test@example.com",
           public_sub: "public-sub-123",
         },
-        journeyActions: [{ action: "temp-account-delete-action" }],
+        journeyActions: [
+          { action: "temp-account-delete-action", startedAt: 500 },
+        ],
       } as unknown as typeof mockRequest.session;
       mockGetCommonAuditEventProps.mockReturnValue({
         user: { session_id: "session-123" },
@@ -392,8 +398,8 @@ describe("journeyActions", () => {
 
     it("should complete all in-progress actions unsuccessfully", async () => {
       mockRequest.session.journeyActions = [
-        { action: "temp-account-delete-action" },
-        { action: "passkey-create" },
+        { action: "temp-account-delete-action", startedAt: 500 },
+        { action: "passkey-create", startedAt: 600 },
       ] as FastifySessionObject["journeyActions"];
 
       await completeAllJourneyActionsUnsuccessfully(
@@ -415,7 +421,8 @@ describe("journeyActions", () => {
             description: "UserAbortedJourney",
             destroySession: false,
           },
-          timestamp: 3000,
+          startedAt: 500,
+          completedAt: 3000,
         },
         {
           action: "passkey-create",
@@ -425,7 +432,8 @@ describe("journeyActions", () => {
             description: "UserAbortedJourney",
             destroySession: false,
           },
-          timestamp: 3000,
+          startedAt: 600,
+          completedAt: 3000,
         },
       ]);
     });
@@ -436,9 +444,10 @@ describe("journeyActions", () => {
           action: "temp-account-delete-action",
           success: true,
           details: {},
-          timestamp: 1000,
+          startedAt: 500,
+          completedAt: 1000,
         },
-        { action: "passkey-create" },
+        { action: "passkey-create", startedAt: 600 },
       ] as FastifySessionObject["journeyActions"];
 
       await completeAllJourneyActionsUnsuccessfully(
@@ -456,7 +465,8 @@ describe("journeyActions", () => {
           action: "temp-account-delete-action",
           success: true,
           details: {},
-          timestamp: 1000,
+          startedAt: 500,
+          completedAt: 1000,
         },
         {
           action: "passkey-create",
@@ -466,7 +476,8 @@ describe("journeyActions", () => {
             description: "UserSignedOut",
             destroySession: true,
           },
-          timestamp: 3000,
+          startedAt: 600,
+          completedAt: 3000,
         },
       ]);
     });
@@ -481,8 +492,8 @@ describe("journeyActions", () => {
           public_sub: "public-sub-123",
         },
         journeyActions: [
-          { action: "temp-account-delete-action" },
-          { action: "passkey-create" },
+          { action: "temp-account-delete-action", startedAt: 500 },
+          { action: "passkey-create", startedAt: 600 },
         ],
       } as unknown as typeof mockRequest.session;
       mockGetCommonAuditEventProps.mockReturnValue({

--- a/solutions/frontend/src/journeys/utils/journeyActions.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.ts
@@ -47,18 +47,21 @@ export type JourneyAction<
 > =
   | {
       action: Name;
+      startedAt: number;
     }
   | {
       action: Name;
       success: false;
       error: (typeof unsuccessfulJourneyActionErrors)[keyof typeof unsuccessfulJourneyActionErrors];
-      timestamp: number;
+      startedAt: number;
+      completedAt: number;
     }
   | {
       action: Name;
       success: true;
       details: Details;
-      timestamp: number;
+      startedAt: number;
+      completedAt: number;
     };
 
 interface JourneyActionDetails {
@@ -76,19 +79,19 @@ type JourneyActions = {
   >;
 };
 
-type InProgressAction<T extends JourneyAction<JourneyActionName>> = Exclude<
-  T,
-  { success: boolean }
+type InProgressAction<T extends JourneyAction<JourneyActionName>> = Omit<
+  Exclude<T, { success: boolean }>,
+  "startedAt"
 >;
 
 type SuccessfulAction<T extends JourneyAction<JourneyActionName>> = Omit<
   Extract<T, { success: true }>,
-  "timestamp" | "success"
+  "startedAt" | "completedAt" | "success"
 >;
 
 type FailedAction = Omit<
   Extract<JourneyActions[keyof JourneyActions], { success: false }>,
-  "timestamp" | "success"
+  "startedAt" | "completedAt" | "success"
 >;
 
 export const startJourneyAction = async <
@@ -106,7 +109,10 @@ export const startJourneyAction = async <
   );
 
   if (!inProgressActionExists) {
-    request.session.journeyActions.push(action);
+    request.session.journeyActions.push({
+      ...action,
+      startedAt: Date.now(),
+    });
 
     if (request.awsLambda?.event) {
       assert.ok(request.session.claims);
@@ -141,8 +147,11 @@ export const startJourneyAction = async <
   }
 };
 
-const updateInProgressAction = (
-  action: DistributiveOmit<JourneyAction<JourneyActionName>, "timestamp"> & {
+const completeInProgressAction = (
+  action: DistributiveOmit<
+    JourneyAction<JourneyActionName>,
+    "startedAt" | "completedAt"
+  > & {
     success: boolean;
   },
   request: FastifyRequest,
@@ -161,8 +170,13 @@ const updateInProgressAction = (
       `In progress action of type "${action.action}" not found in journey actions`,
     );
   }
+  assert.ok(request.session.journeyActions[index]);
 
-  request.session.journeyActions[index] = { ...action, timestamp: Date.now() };
+  request.session.journeyActions[index] = {
+    ...request.session.journeyActions[index],
+    ...action,
+    completedAt: Date.now(),
+  };
 };
 
 const sendCompletedActionAuditEvent = async (
@@ -224,7 +238,7 @@ export const completeJourneyActionSuccessfully = async <
     name: action.action,
     success: true,
   });
-  updateInProgressAction({ ...action, success: true }, request);
+  completeInProgressAction({ ...action, success: true }, request);
 };
 
 export const completeJourneyActionUnsuccessfully = async (
@@ -237,7 +251,7 @@ export const completeJourneyActionUnsuccessfully = async (
     success: false,
     error: action.error.description,
   });
-  updateInProgressAction({ ...action, success: false }, request);
+  completeInProgressAction({ ...action, success: false }, request);
 };
 
 export const completeAllJourneyActionsUnsuccessfully = async (
@@ -263,7 +277,7 @@ export const completeAllJourneyActionsUnsuccessfully = async (
         success: false,
         error: error.description,
       });
-      updateInProgressAction(
+      completeInProgressAction(
         { action: journeyActionName, error, success: false },
         request,
       );

--- a/solutions/integration-tests/tests/features/@delete-account.feature
+++ b/solutions/integration-tests/tests/features/@delete-account.feature
@@ -51,18 +51,18 @@ Feature: Delete account
   
     Given I click the "Delete your GOV.UK One Login" button
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "account-delete",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
-    """
-    And the page contains the text:
-    """
-    "action": "temp-account-delete-action",
-    "details": {},
-    "success": true,
+    {
+      "actions": [{
+        "action": "temp-account-delete-action",
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "account-delete",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -80,23 +80,24 @@ Feature: Delete account
 
     Given I click the "try signing in again" link
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "account-delete",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "temp-account-delete-action",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
+    {
+      "actions": [{
+        "action": "temp-account-delete-action",
+        "details": {
+          "error": {
+            "code": 1002,
+            "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "account-delete",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -118,23 +119,24 @@ Feature: Delete account
 
     Given I click the "try signing in again" link
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "account-delete",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "temp-account-delete-action",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
+    {
+      "actions": [{
+        "action": "temp-account-delete-action",
+        "details": {
+          "error": {
+            "code": 1002,
+            "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "account-delete",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -160,23 +162,24 @@ Feature: Delete account
 
     Given I click the "try signing in again" link
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "account-delete",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "temp-account-delete-action",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
+    {
+      "actions": [{
+        "action": "temp-account-delete-action",
+        "details": {
+          "error": {
+            "code": 1002,
+            "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "account-delete",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -194,21 +197,22 @@ Feature: Delete account
 
     Given I click the "try signing in again" link
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "account-delete",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
+    {
+      "actions": [{
+        "action": "temp-account-delete-action",
+        "details": {
+          "error": {
+            "code": 1002,
+            "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "account-delete",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
-    And the page contains the text:
-    """
-    "action": "temp-account-delete-action",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
-    """    

--- a/solutions/integration-tests/tests/features/@journey-state.feature
+++ b/solutions/integration-tests/tests/features/@journey-state.feature
@@ -50,79 +50,79 @@ Feature: Journey state
     Then the page title is prefixed with "Testing journey confirmation"
 
     Given I click the "Complete testing journey" button
-    Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'    
-    And the page contains the text:
+    Then the page contains the text "Client callback"  
+    And the journey outcome matches the object:
     """
-    "scope": "testing-journey",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "testing-journey-action",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "testing-journey",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
-    And the page contains the text:
-    """
-    "action": "testing-journey-action",
-    "details": {},
-    "success": true,
-    """    
 
     # Shouldn't be able to access any journey pages after finishing journey
     Given I click the browser's back button
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'    
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "testing-journey",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "testing-journey-action",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "testing-journey",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
-    And the page contains the text:
-    """
-    "action": "testing-journey-action",
-    "details": {},
-    "success": true,
-    """    
     Given I go to the "Testing journey - step 1" page   
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'    
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "testing-journey",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
-    """
-    And the page contains the text:
-    """
-    "action": "testing-journey-action",
-    "details": {},
-    "success": true,
+    {
+      "actions": [{
+        "action": "testing-journey-action",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "testing-journey",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     Given I go to the "Testing journey - enter password" page   
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'    
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "testing-journey",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "testing-journey-action",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "testing-journey",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
-    And the page contains the text:
-    """
-    "action": "testing-journey-action",
-    "details": {},
-    "success": true,
-    """ 
     Given I go to the "Testing journey - confirmation" page   
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'    
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "testing-journey",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "testing-journey-action",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "testing-journey",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
-    And the page contains the text:
-    """
-    "action": "testing-journey-action",
-    "details": {},
-    "success": true,
-    """   

--- a/solutions/integration-tests/tests/features/@page-chrome.feature
+++ b/solutions/integration-tests/tests/features/@page-chrome.feature
@@ -18,24 +18,25 @@ Feature: Page chrome
     And the account navigation is present and contains the expected links
     Given I click the sign out button in the header
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "testing-journey",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
+    {
+      "actions": [{
+        "action": "testing-journey-action",
+        "details": {
+          "error": {
+            "code": 1001,
+            "description": "UserSignedOut"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "testing-journey",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
-    And the page contains the text:
-    """
-    "action": "testing-journey-action",
-    "details": {
-      "error": {
-        "code": 1001,
-        "description": "UserSignedOut"
-      }      
-    },
-    "success": false,
-    """ 
 
   Scenario: Navigate via app channel
     Given I go to the journey initiator

--- a/solutions/integration-tests/tests/features/@passkey-create.feature
+++ b/solutions/integration-tests/tests/features/@passkey-create.feature
@@ -9,23 +9,24 @@ Feature: Passkey create
 
     Given I click the "Back" link
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "passkey-create",
-    "details": {
-      "error": {
-        "code": 1003,
-        "description": "UserBackedOutOfJourney"
-      }      
-    },
-    "success": false,
+    {
+      "actions": [{
+        "action": "passkey-create",
+        "details": {
+          "error": {
+          "code": 1003,
+          "description": "UserBackedOutOfJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -40,23 +41,24 @@ Feature: Passkey create
 
     Given I click the "Skip for now" link
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "passkey-create",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
+    {
+      "actions": [{
+        "action": "passkey-create",
+        "details": {
+          "error": {
+          "code": 1002,
+          "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -87,23 +89,24 @@ Feature: Passkey create
     Given I select the option beginning with "Skip for now" in the "What would you like to do?" radio button group
     And I click the "Continue" button
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "passkey-create",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
+    {
+      "actions": [{
+        "action": "passkey-create",
+        "details": {
+          "error": {
+          "code": 1002,
+          "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -119,23 +122,24 @@ Feature: Passkey create
 
     Given I click the "Cancel and go back" link
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "passkey-create",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
+    {
+      "actions": [{
+        "action": "passkey-create",
+        "details": {
+          "error": {
+          "code": 1002,
+          "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
     """
 
   # Should fail because of known accessibility issues
@@ -167,24 +171,25 @@ Feature: Passkey create
     Given I select the option beginning with "Cancel and go back" in the "What would you like to do?" radio button group
     And I click the "Continue" button
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "passkey-create",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
-    """    
+    {
+      "actions": [{
+        "action": "passkey-create",
+        "details": {
+          "error": {
+          "code": 1002,
+          "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
+    """  
     
   Scenario: Successfully create a passkey
     Given I go to the journey initiator
@@ -197,17 +202,20 @@ Feature: Passkey create
     """    
     And I click the "Continue" button
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "passkey-create",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     And the page contains the text '"aaguid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
-    And the page contains the text '"action": "passkey-create",'    
-    And the page contains the text '"success": true,'     
-    And the page does not contain the text '"success": false'  
 
   Scenario: User has maximum number of passkeys
     Given I go to the journey initiator
@@ -244,17 +252,20 @@ Feature: Passkey create
     And I select the option beginning with "Try setting up a passkey again" in the "What would you like to do?" radio button group   
     And I click the "Continue" button
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "passkey-create",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     And the page contains the text '"aaguid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
-    And the page contains the text '"action": "passkey-create",'    
-    And the page contains the text '"success": true,'     
-    And the page does not contain the text '"success": false'  
 
   Scenario: Invalid authenticators
     Given I go to the journey initiator
@@ -333,17 +344,20 @@ Feature: Passkey create
     """    
     And I click the "Continue" button    
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "passkey-create",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     And the page contains the text '"aaguid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
-    And the page contains the text '"action": "passkey-create",'    
-    And the page contains the text '"success": true,'     
-    And the page does not contain the text '"success": false'  
 
     Given I have no authenticators
     And I go to the journey initiator
@@ -357,17 +371,20 @@ Feature: Passkey create
     """    
     And I click the "Continue" button    
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "passkey-create",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     And the page contains the text '"aaguid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
-    And the page contains the text '"action": "passkey-create",'    
-    And the page contains the text '"success": true,'     
-    And the page does not contain the text '"success": false'  
 
     Given I have no authenticators
     And I go to the journey initiator
@@ -381,17 +398,20 @@ Feature: Passkey create
     """    
     And I click the "Continue" button    
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "passkey-create",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     And the page contains the text '"aaguid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
-    And the page contains the text '"action": "passkey-create",'    
-    And the page contains the text '"success": true,'       
-    And the page does not contain the text '"success": false'  
 
     Given I have no authenticators
     And I go to the journey initiator
@@ -405,17 +425,20 @@ Feature: Passkey create
     """    
     And I click the "Continue" button    
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "passkey-create",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     And the page contains the text '"aaguid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
-    And the page contains the text '"action": "passkey-create",'    
-    And the page contains the text '"success": true,'     
-    And the page does not contain the text '"success": false'  
 
     Given I have no authenticators
     And I go to the journey initiator
@@ -430,17 +453,20 @@ Feature: Passkey create
     """    
     And I click the "Continue" button    
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": true
+    {
+      "actions": [{
+        "action": "passkey-create",      
+        "success": true
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": true
+    }    
     """
     And the page contains the text '"aaguid": "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"'
-    And the page contains the text '"action": "passkey-create",'    
-    And the page contains the text '"success": true,'     
-    And the page does not contain the text '"success": false'  
 
   @noJs
   Scenario: JavaScript disabled
@@ -462,21 +488,22 @@ Feature: Passkey create
     Given I select the option beginning with "Skip for now" in the "What would you like to do?" radio button group
     And I click the "Continue" button
     Then the page contains the text "Client callback"
-    And the page contains the text '"email": "testuser@test.null.local",'
-    And the page contains the text:
+    And the journey outcome matches the object:
     """
-    "scope": "passkey-create",
-    "sub": "urn:fdc:gov.uk:default",
-    "success": false
-    """
-    And the page contains the text:
-    """
-    "action": "passkey-create",
-    "details": {
-      "error": {
-        "code": 1002,
-        "description": "UserAbortedJourney"
-      }      
-    },
-    "success": false,
-    """
+    {
+      "actions": [{
+        "action": "passkey-create",
+        "details": {
+          "error": {
+          "code": 1002,
+          "description": "UserAbortedJourney"
+          }      
+        },        
+        "success": false
+      }],
+      "email": "testuser@test.null.local",
+      "scope": "passkey-create",
+      "sub": "urn:fdc:gov.uk:default",
+      "success": false
+    }    
+    """ 

--- a/solutions/integration-tests/tests/steps/shared.ts
+++ b/solutions/integration-tests/tests/steps/shared.ts
@@ -95,10 +95,6 @@ Then(
   },
 );
 
-Then("the page contains the text:", async ({ page }, text: string) => {
-  await expect(page.getByText(text)).toBeVisible();
-});
-
 Then("the page looks as expected", async ({ page }) => {
   // eslint-disable-next-line playwright/no-networkidle
   await page.waitForLoadState("networkidle");
@@ -283,5 +279,21 @@ Then(
     const currentUrl = new URL(page.url());
     const paramValue = currentUrl.searchParams.get(paramName);
     expect(paramValue).toBe(expectedValue);
+  },
+);
+
+Then(
+  "the journey outcome matches the object:",
+  async ({ page }, jsonObject: string) => {
+    const journeyOutcomeDetailsElement = page.locator("#journeyOutcomeDetails");
+    const journeyOutcomeDetailsJson =
+      await journeyOutcomeDetailsElement.textContent();
+    assert.ok(journeyOutcomeDetailsJson !== null);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const journeyOutcomeDetails = JSON.parse(journeyOutcomeDetailsJson);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const object = JSON.parse(jsonObject);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    expect(journeyOutcomeDetails).toMatchObject(object);
   },
 );

--- a/solutions/stubs/src/clientCallback/handlers/clientCallback.njk
+++ b/solutions/stubs/src/clientCallback/handlers/clientCallback.njk
@@ -27,7 +27,7 @@
     {% endif %}
     {% if journeyOutcomeDetails %}
         <p>Journey outcome details:</p>
-        <pre>{{ journeyOutcomeDetails | dump(2) | safe }}</pre>
+        <pre id="journeyOutcomeDetails">{{ journeyOutcomeDetails | dump(2) | safe }}</pre>
     {% endif %}        
     {% if exception %}
         <p>An error occurred:</p>


### PR DESCRIPTION
## OLH-4448: Explicit action start and end times

Replaced the single `timestamp` field on journey actions with separate `startedAt` and `completedAt` fields, providing explicit timing for both when an action begins and when it ends.

### Changes

- **`JourneyAction` type** — in-progress actions now carry `startedAt`; completed actions (success or failure) carry both `startedAt` and `completedAt` instead of the previous `timestamp`
- **`startJourneyAction`** — sets `startedAt: Date.now()` when pushing a new action onto the session
- **`completeInProgressAction`** (renamed from `updateInProgressAction`) — spreads the existing action to preserve `startedAt`, then sets `completedAt: Date.now()`
- **Tests updated** across `journeyActions.test.ts`, `completeJourney.test.ts`, and `confirm.test.ts` to reflect the new shape
- **Integration test feature files** updated to match the new timing fields in journey state assertions