### PR TITLE
BAU: Ensure consistent timestamps when completing journey actions

### DIFF
--- a/solutions/frontend/src/journeys/utils/journeyActions.test.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.test.ts
@@ -38,6 +38,10 @@ describe("journeyActions", () => {
   });
 
   describe("startAction", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ now: 1500 });
+    });
+
     it("should initialise journeyActions and push the action when journeyActions is undefined", async () => {
       await startJourneyAction<"tempAccountDeleteAction">(
         { action: "temp-account-delete-action" },
@@ -46,7 +50,7 @@ describe("journeyActions", () => {
       );
 
       expect(mockRequest.session.journeyActions).toStrictEqual([
-        { action: "temp-account-delete-action", startedAt: expect.any(Number) },
+        { action: "temp-account-delete-action", startedAt: 1500 },
       ]);
     });
 
@@ -63,7 +67,7 @@ describe("journeyActions", () => {
 
       expect(mockRequest.session.journeyActions).toStrictEqual([
         { action: "temp-account-delete-action", startedAt: 500 },
-        { action: "passkey-create", startedAt: expect.any(Number) },
+        { action: "passkey-create", startedAt: 1500 },
       ]);
     });
 
@@ -108,6 +112,8 @@ describe("journeyActions", () => {
       expect(mockCreateEvent).toHaveBeenCalledWith(
         "AMC_ACTION_STARTED",
         expect.objectContaining({
+          timestamp: 1,
+          event_timestamp_ms: 1500,
           event_name: "AMC_ACTION_STARTED",
           client_id: "client-123",
           extensions: expect.objectContaining({

--- a/solutions/frontend/src/journeys/utils/journeyActions.test.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.test.ts
@@ -223,6 +223,8 @@ describe("journeyActions", () => {
       expect(mockCreateEvent).toHaveBeenCalledWith(
         "AMC_ACTION_COMPLETED",
         expect.objectContaining({
+          timestamp: 1,
+          event_timestamp_ms: 1000,
           event_name: "AMC_ACTION_COMPLETED",
           extensions: expect.objectContaining({
             account_action: "temp-account-delete-action",
@@ -347,6 +349,8 @@ describe("journeyActions", () => {
       expect(mockCreateEvent).toHaveBeenCalledWith(
         "AMC_ACTION_COMPLETED",
         expect.objectContaining({
+          timestamp: 2,
+          event_timestamp_ms: 2000,
           event_name: "AMC_ACTION_COMPLETED",
           extensions: expect.objectContaining({
             account_action: "temp-account-delete-action",
@@ -482,7 +486,7 @@ describe("journeyActions", () => {
       ]);
     });
 
-    it("should send audit events for each in-progress action", async () => {
+    it("should send audit events for each in-progress action with the same timestamp", async () => {
       mockRequest.awsLambda = { event: { requestContext: {} } };
       mockRequest.session = {
         claims: {
@@ -513,6 +517,17 @@ describe("journeyActions", () => {
       );
 
       expect(mockSendAuditEvent).toHaveBeenCalledTimes(2);
+      expect(mockCreateEvent).toHaveBeenCalledTimes(2);
+      expect(mockCreateEvent).toHaveBeenNthCalledWith(
+        1,
+        "AMC_ACTION_COMPLETED",
+        expect.objectContaining({ timestamp: 3, event_timestamp_ms: 3000 }),
+      );
+      expect(mockCreateEvent).toHaveBeenNthCalledWith(
+        2,
+        "AMC_ACTION_COMPLETED",
+        expect.objectContaining({ timestamp: 3, event_timestamp_ms: 3000 }),
+      );
     });
 
     it("should complete all in-progress actions unsuccessfully with complex error including extras", async () => {

--- a/solutions/frontend/src/journeys/utils/journeyActions.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.ts
@@ -151,9 +151,11 @@ export const startJourneyAction = async <
   );
 
   if (!inProgressActionExists) {
+    const startedAt = new Date().getTime();
+
     request.session.journeyActions.push({
       ...action,
-      startedAt: Date.now(),
+      startedAt,
     });
 
     if (request.awsLambda?.event) {
@@ -166,6 +168,8 @@ export const startJourneyAction = async <
       await sendAuditEvent(
         createEvent("AMC_ACTION_STARTED", {
           ...commonAuditEventProps,
+          timestamp: Math.floor(startedAt / 1000),
+          event_timestamp_ms: startedAt,
           event_name: "AMC_ACTION_STARTED",
           client_id: request.session.claims.client_id,
           extensions: {

--- a/solutions/frontend/src/journeys/utils/journeyActions.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.ts
@@ -190,6 +190,7 @@ export const startJourneyAction = async <
 };
 
 const completeInProgressAction = (
+  completedAt: Date,
   action: DistributiveOmit<
     JourneyAction<JourneyActionName>,
     "startedAt" | "completedAt"
@@ -217,11 +218,12 @@ const completeInProgressAction = (
   request.session.journeyActions[index] = {
     ...request.session.journeyActions[index],
     ...action,
-    completedAt: Date.now(),
+    completedAt: completedAt.getTime(),
   };
 };
 
 const sendCompletedActionAuditEvent = async (
+  completedAt: Date,
   request: FastifyRequest,
   reply: FastifyReply,
   action:
@@ -245,6 +247,8 @@ const sendCompletedActionAuditEvent = async (
     await sendAuditEvent(
       createEvent("AMC_ACTION_COMPLETED", {
         ...commonAuditEventProps,
+        timestamp: Math.floor(completedAt.getTime() / 1000),
+        event_timestamp_ms: completedAt.getTime(),
         event_name: "AMC_ACTION_COMPLETED",
         client_id: request.session.claims.client_id,
         extensions: {
@@ -276,11 +280,12 @@ export const completeJourneyActionSuccessfully = async <
   request: FastifyRequest,
   reply: FastifyReply,
 ) => {
-  await sendCompletedActionAuditEvent(request, reply, {
+  const completedAt = new Date();
+  await sendCompletedActionAuditEvent(completedAt, request, reply, {
     name: action.action,
     success: true,
   });
-  completeInProgressAction({ ...action, success: true }, request);
+  completeInProgressAction(completedAt, { ...action, success: true }, request);
 };
 
 export const completeJourneyActionUnsuccessfully = async (
@@ -288,12 +293,13 @@ export const completeJourneyActionUnsuccessfully = async (
   request: FastifyRequest,
   reply: FastifyReply,
 ) => {
-  await sendCompletedActionAuditEvent(request, reply, {
+  const completedAt = new Date();
+  await sendCompletedActionAuditEvent(completedAt, request, reply, {
     name: action.action,
     success: false,
     error: action.error.description,
   });
-  completeInProgressAction({ ...action, success: false }, request);
+  completeInProgressAction(completedAt, { ...action, success: false }, request);
 };
 
 export const completeAllJourneyActionsUnsuccessfully = async (
@@ -315,6 +321,8 @@ export const completeAllJourneyActionsUnsuccessfully = async (
     "There are no journey actions",
   );
 
+  const completedAt = new Date();
+
   for (const journeyAction of request.session.journeyActions) {
     if (!("success" in journeyAction)) {
       const journeyActionName = Object.values(journeyActionNames).find(
@@ -323,12 +331,13 @@ export const completeAllJourneyActionsUnsuccessfully = async (
 
       assert.ok(journeyActionName, "Action not found");
 
-      await sendCompletedActionAuditEvent(request, reply, {
+      await sendCompletedActionAuditEvent(completedAt, request, reply, {
         name: journeyActionName,
         success: false,
         error: error.description,
       });
       completeInProgressAction(
+        completedAt,
         { action: journeyActionName, error, success: false },
         request,
       );


### PR DESCRIPTION
Pass a `Date` instance into `completeInProgressAction` and `sendCompletedActionAuditEvent` rather than calling `Date.now()` / deriving timestamps internally. Each call site creates a single `new Date()` and passes it to both functions, so the `completedAt` value stored on the journey action and the `timestamp` / `event_timestamp_ms` fields on the audit event are always identical.

This also means that when `completeAllJourneyActionsUnsuccessfully` processes multiple in-progress actions, all of them share the same `completedAt` timestamp and audit event timestamps.