### PR TITLE
BAU: Extract shared OTP sending logic into sharedSendOtpHandler

### DIFF
--- a/solutions/commons/utils/auditEvents/index.ts
+++ b/solutions/commons/utils/auditEvents/index.ts
@@ -8,14 +8,14 @@ export const getCommonAuditEventProps = (
   apiGatewayProxyEvent?: APIGatewayProxyEvent,
 ) => {
   const noValue = "NO_VALUE";
-  const now = new Date();
+  const now = Date.now();
   const propsFromEvent = apiGatewayProxyEvent
     ? getPropsFromAPIGatewayEvent(apiGatewayProxyEvent)
     : undefined;
 
   return {
-    timestamp: Math.floor(now.getTime() / 1000),
-    event_timestamp_ms: now.getTime(),
+    timestamp: Math.floor(now / 1000),
+    event_timestamp_ms: now,
     component_id: "AMC" as const,
     user: {
       session_id: propsFromEvent?.sessionId ?? noValue,

--- a/solutions/frontend/src/journeys/account-delete/handlers/introduction.test.ts
+++ b/solutions/frontend/src/journeys/account-delete/handlers/introduction.test.ts
@@ -1,16 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { FastifyRequest, FastifyReply } from "fastify";
 
-const mockSendOtpChallenge = vi.fn();
+const mockSharedSendOtpHandler = vi.fn();
 const mockStartJourneyAction = vi.fn();
 
-// @ts-expect-error
-vi.mock(import("../../../utils/accountManagementApiClient.js"), () => ({
-  AccountManagementApiClient: vi.fn().mockImplementation(function () {
-    return {
-      sendOtpChallenge: mockSendOtpChallenge,
-    };
-  }),
+vi.mock(import("../utils/sharedSendOtpHandler.js"), () => ({
+  sharedSendOtpHandler: mockSharedSendOtpHandler,
 }));
 
 vi.mock(import("../../utils/journeyActions.js"), async (importOriginal) => ({
@@ -28,24 +23,11 @@ describe("introduction handlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockRequest = {
-      session: {
-        // @ts-expect-error
-        claims: {
-          account_management_api_access_token: "test-token",
-          public_sub: "test-public-sub",
-        },
-      },
-    };
+    mockRequest = {};
     mockReply = {
       render: vi.fn().mockResolvedValue(undefined),
       redirect: vi.fn().mockReturnThis(),
-      journeyStates: {
-        "account-delete": {
-          send: vi.fn(),
-        },
-      } as unknown as FastifyReply["journeyStates"],
-    } as unknown as FastifyReply;
+    };
   });
 
   describe("introductionGetHandler", () => {
@@ -80,95 +62,17 @@ describe("introduction handlers", () => {
   });
 
   describe("introductionPostHandler", () => {
-    it("should send OTP challenge and redirect to verify email address page on success", async () => {
-      mockSendOtpChallenge.mockResolvedValue({ success: true });
+    it("should delegate to sharedSendOtpHandler and return its result", async () => {
+      mockSharedSendOtpHandler.mockResolvedValue(mockReply);
 
       const result = await introductionPostHandler(
         mockRequest as FastifyRequest,
         mockReply as FastifyReply,
       );
 
-      expect(mockSendOtpChallenge).toHaveBeenCalledWith("test-public-sub");
-      expect(mockReply.redirect).toHaveBeenCalledWith(
-        "/reset-delete/check-email",
-      );
-      expect(result).toBe(mockReply);
-    });
-
-    it("should throw if session claims are not available", async () => {
-      delete mockRequest.session;
-
-      await expect(
-        introductionPostHandler(
-          mockRequest as FastifyRequest,
-          mockReply as FastifyReply,
-        ),
-      ).rejects.toThrow();
-    });
-
-    it("should throw if access token is not available", async () => {
-      // @ts-expect-error
-      delete mockRequest.session.claims.account_management_api_access_token;
-
-      await expect(
-        introductionPostHandler(
-          mockRequest as FastifyRequest,
-          mockReply as FastifyReply,
-        ),
-      ).rejects.toThrow();
-    });
-
-    it("should throw if journey states are not available", async () => {
-      delete mockReply.journeyStates;
-
-      await expect(
-        introductionPostHandler(
-          mockRequest as FastifyRequest,
-          mockReply as FastifyReply,
-        ),
-      ).rejects.toThrow();
-    });
-
-    it("should send lockedOutSecurityCodeEnteredTooManyTimes event and redirect when TooManyEmailCodesEntered", async () => {
-      mockSendOtpChallenge.mockResolvedValue({
-        success: false,
-        error: "TooManyEmailCodesEntered",
-      });
-
-      const result = await introductionPostHandler(
-        mockRequest as FastifyRequest,
-        mockReply as FastifyReply,
-      );
-
-      expect(
-        mockReply.journeyStates?.["account-delete"]?.send,
-      ).toHaveBeenCalledWith({
-        type: "lockedOutSecurityCodeEnteredTooManyTimes",
-      });
-      expect(mockReply.redirect).toHaveBeenCalledWith(
-        "/reset-delete/security-code-entered-exceeded",
-      );
-      expect(result).toBe(mockReply);
-    });
-
-    it("should send lockedOutSecurityCodeRequestedTooManyTimes event and redirect when BlockedForEmailVerificationCodes", async () => {
-      mockSendOtpChallenge.mockResolvedValue({
-        success: false,
-        error: "BlockedForEmailVerificationCodes",
-      });
-
-      const result = await introductionPostHandler(
-        mockRequest as FastifyRequest,
-        mockReply as FastifyReply,
-      );
-
-      expect(
-        mockReply.journeyStates?.["account-delete"]?.send,
-      ).toHaveBeenCalledWith({
-        type: "lockedOutSecurityCodeRequestedTooManyTimes",
-      });
-      expect(mockReply.redirect).toHaveBeenCalledWith(
-        "/reset-delete/security-code-requested-too-many-times",
+      expect(mockSharedSendOtpHandler).toHaveBeenCalledWith(
+        mockRequest,
+        mockReply,
       );
       expect(result).toBe(mockReply);
     });

--- a/solutions/frontend/src/journeys/account-delete/handlers/introduction.ts
+++ b/solutions/frontend/src/journeys/account-delete/handlers/introduction.ts
@@ -1,8 +1,7 @@
 import { type FastifyReply, type FastifyRequest } from "fastify";
 import assert from "node:assert";
-import { paths } from "../../../utils/paths.js";
-import { AccountManagementApiClient } from "../../../utils/accountManagementApiClient.js";
 import { startJourneyAction } from "../../utils/journeyActions.js";
+import { sharedSendOtpHandler } from "../utils/sharedSendOtpHandler.js";
 
 const render = async (reply: FastifyReply, options?: object) => {
   assert.ok(reply.render);
@@ -29,47 +28,5 @@ export async function introductionPostHandler(
   request: FastifyRequest,
   reply: FastifyReply,
 ) {
-  assert.ok(request.session.claims);
-  assert.ok(request.session.claims.account_management_api_access_token);
-  assert.ok(reply.journeyStates?.["account-delete"]);
-
-  const accountManagementApiClient = new AccountManagementApiClient(
-    request.session.claims.account_management_api_access_token,
-    request.awsLambda?.event,
-  );
-
-  const result = await accountManagementApiClient.sendOtpChallenge(
-    request.session.claims.public_sub,
-  );
-
-  if (!result.success) {
-    if (result.error === "TooManyEmailCodesEntered") {
-      reply.journeyStates["account-delete"].send({
-        type: "lockedOutSecurityCodeEnteredTooManyTimes",
-      });
-      reply.redirect(
-        paths.journeys["account-delete"]
-          .LOCKED_OUT_SECURITY_CODE_ENTERED_TOO_MANY_TIMES
-          .lockedOutSecurityCodeEnteredTooManyTimes.path,
-      );
-      return reply;
-    } else if (result.error === "BlockedForEmailVerificationCodes") {
-      reply.journeyStates["account-delete"].send({
-        type: "lockedOutSecurityCodeRequestedTooManyTimes",
-      });
-      reply.redirect(
-        paths.journeys["account-delete"]
-          .LOCKED_OUT_SECURITY_CODE_REQUESTED_TOO_MANY_TIMES
-          .lockedOutSecurityCodeRequestedTooManyTimes.path,
-      );
-      return reply;
-    }
-
-    throw new Error(result.error);
-  }
-
-  reply.redirect(
-    paths.journeys["account-delete"].EMAIL_NOT_VERIFIED.verifyEmailAddress.path,
-  );
-  return reply;
+  return await sharedSendOtpHandler(request, reply);
 }

--- a/solutions/frontend/src/journeys/account-delete/handlers/resendEmailVerificationCode.test.ts
+++ b/solutions/frontend/src/journeys/account-delete/handlers/resendEmailVerificationCode.test.ts
@@ -1,15 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { FastifyRequest, FastifyReply } from "fastify";
 
-const mockSendOtpChallenge = vi.fn();
+const mockSharedSendOtpHandler = vi.fn();
 
-// @ts-expect-error
-vi.mock(import("../../../utils/accountManagementApiClient.js"), () => ({
-  AccountManagementApiClient: vi.fn().mockImplementation(function () {
-    return {
-      sendOtpChallenge: mockSendOtpChallenge,
-    };
-  }),
+vi.mock(import("../utils/sharedSendOtpHandler.js"), () => ({
+  sharedSendOtpHandler: mockSharedSendOtpHandler,
 }));
 
 const {
@@ -37,12 +32,7 @@ describe("resendEmailVerificationCode handlers", () => {
     mockReply = {
       render: vi.fn().mockResolvedValue(undefined),
       redirect: vi.fn().mockReturnThis(),
-      journeyStates: {
-        "account-delete": {
-          send: vi.fn(),
-        },
-      } as unknown as FastifyReply["journeyStates"],
-    } as unknown as FastifyReply;
+    };
   });
 
   describe("resendEmailVerificationCodeGetHandler", () => {
@@ -75,97 +65,19 @@ describe("resendEmailVerificationCode handlers", () => {
   });
 
   describe("resendEmailVerificationCodePostHandler", () => {
-    it("should send OTP challenge and redirect to verify email address page on success", async () => {
-      mockSendOtpChallenge.mockResolvedValue({ success: true });
+    it("should delegate to sharedSendOtpHandler and return its result", async () => {
+      mockSharedSendOtpHandler.mockResolvedValue(mockReply);
 
       const result = await resendEmailVerificationCodePostHandler(
         mockRequest as FastifyRequest,
         mockReply as FastifyReply,
       );
 
-      expect(mockSendOtpChallenge).toHaveBeenCalledWith("test-public-sub");
-      expect(mockReply.redirect).toHaveBeenCalledWith(
-        "/reset-delete/check-email",
+      expect(mockSharedSendOtpHandler).toHaveBeenCalledWith(
+        mockRequest,
+        mockReply,
       );
       expect(result).toBe(mockReply);
-    });
-
-    it("should throw if session claims are not available", async () => {
-      delete mockRequest.session;
-
-      await expect(
-        resendEmailVerificationCodePostHandler(
-          mockRequest as FastifyRequest,
-          mockReply as FastifyReply,
-        ),
-      ).rejects.toThrow();
-    });
-
-    it("should throw if access token is not available", async () => {
-      // @ts-expect-error
-      delete mockRequest.session.claims.account_management_api_access_token;
-
-      await expect(
-        resendEmailVerificationCodePostHandler(
-          mockRequest as FastifyRequest,
-          mockReply as FastifyReply,
-        ),
-      ).rejects.toThrow();
-    });
-
-    it("should send lockedOutSecurityCodeEnteredTooManyTimes event and redirect when TooManyEmailCodesEntered", async () => {
-      mockSendOtpChallenge.mockResolvedValue({
-        success: false,
-        error: "TooManyEmailCodesEntered",
-      });
-
-      const result = await resendEmailVerificationCodePostHandler(
-        mockRequest as FastifyRequest,
-        mockReply as FastifyReply,
-      );
-
-      expect(
-        mockReply.journeyStates?.["account-delete"]?.send,
-      ).toHaveBeenCalledWith({
-        type: "lockedOutSecurityCodeEnteredTooManyTimes",
-      });
-      expect(mockReply.redirect).toHaveBeenCalledWith(
-        "/reset-delete/security-code-entered-exceeded",
-      );
-      expect(result).toBe(mockReply);
-    });
-
-    it("should send lockedOutSecurityCodeRequestedTooManyTimes event and redirect when BlockedForEmailVerificationCodes", async () => {
-      mockSendOtpChallenge.mockResolvedValue({
-        success: false,
-        error: "BlockedForEmailVerificationCodes",
-      });
-
-      const result = await resendEmailVerificationCodePostHandler(
-        mockRequest as FastifyRequest,
-        mockReply as FastifyReply,
-      );
-
-      expect(
-        mockReply.journeyStates?.["account-delete"]?.send,
-      ).toHaveBeenCalledWith({
-        type: "lockedOutSecurityCodeRequestedTooManyTimes",
-      });
-      expect(mockReply.redirect).toHaveBeenCalledWith(
-        "/reset-delete/security-code-requested-too-many-times",
-      );
-      expect(result).toBe(mockReply);
-    });
-
-    it("should throw if journey states are not available", async () => {
-      delete mockReply.journeyStates;
-
-      await expect(
-        resendEmailVerificationCodePostHandler(
-          mockRequest as FastifyRequest,
-          mockReply as FastifyReply,
-        ),
-      ).rejects.toThrow();
     });
   });
 });

--- a/solutions/frontend/src/journeys/account-delete/handlers/resendEmailVerificationCode.ts
+++ b/solutions/frontend/src/journeys/account-delete/handlers/resendEmailVerificationCode.ts
@@ -1,7 +1,7 @@
 import { type FastifyReply, type FastifyRequest } from "fastify";
 import assert from "node:assert";
 import { paths } from "../../../utils/paths.js";
-import { introductionPostHandler } from "./introduction.js";
+import { sharedSendOtpHandler } from "../utils/sharedSendOtpHandler.js";
 
 const render = async (
   request: FastifyRequest,
@@ -35,10 +35,5 @@ export async function resendEmailVerificationCodePostHandler(
   request: FastifyRequest,
   reply: FastifyReply,
 ) {
-  // Only make use of introductionPostHandler whilst this handler
-  // contains no different logic. If this handler needs to have
-  // different logic to introductionPostHandler then don't call
-  // introductionPostHandler and add the logic directly in this
-  // handler.
-  return await introductionPostHandler(request, reply);
+  return await sharedSendOtpHandler(request, reply);
 }

--- a/solutions/frontend/src/journeys/account-delete/utils/sharedSendOtpHandler.test.ts
+++ b/solutions/frontend/src/journeys/account-delete/utils/sharedSendOtpHandler.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FastifyRequest, FastifyReply } from "fastify";
+
+const mockSendOtpChallenge = vi.fn();
+
+// @ts-expect-error
+vi.mock(import("../../../utils/accountManagementApiClient.js"), () => ({
+  AccountManagementApiClient: vi.fn().mockImplementation(function () {
+    return {
+      sendOtpChallenge: mockSendOtpChallenge,
+    };
+  }),
+}));
+
+const { sharedSendOtpHandler } = await import("./sharedSendOtpHandler.js");
+
+describe("sharedSendOtpHandler", () => {
+  let mockRequest: Partial<FastifyRequest>;
+  let mockReply: Partial<FastifyReply>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockRequest = {
+      session: {
+        // @ts-expect-error
+        claims: {
+          account_management_api_access_token: "test-token",
+          public_sub: "test-public-sub",
+        },
+      },
+    };
+    mockReply = {
+      redirect: vi.fn().mockReturnThis(),
+      journeyStates: {
+        "account-delete": {
+          send: vi.fn(),
+        },
+      } as unknown as FastifyReply["journeyStates"],
+    } as unknown as FastifyReply;
+  });
+
+  it("should send OTP challenge and redirect to verify email address page on success", async () => {
+    mockSendOtpChallenge.mockResolvedValue({ success: true });
+
+    const result = await sharedSendOtpHandler(
+      mockRequest as FastifyRequest,
+      mockReply as FastifyReply,
+    );
+
+    expect(mockSendOtpChallenge).toHaveBeenCalledWith("test-public-sub");
+    expect(mockReply.redirect).toHaveBeenCalledWith(
+      "/reset-delete/check-email",
+    );
+    expect(result).toBe(mockReply);
+  });
+
+  it("should send lockedOutSecurityCodeEnteredTooManyTimes event and redirect when TooManyEmailCodesEntered", async () => {
+    mockSendOtpChallenge.mockResolvedValue({
+      success: false,
+      error: "TooManyEmailCodesEntered",
+    });
+
+    const result = await sharedSendOtpHandler(
+      mockRequest as FastifyRequest,
+      mockReply as FastifyReply,
+    );
+
+    expect(
+      mockReply.journeyStates?.["account-delete"]?.send,
+    ).toHaveBeenCalledWith({
+      type: "lockedOutSecurityCodeEnteredTooManyTimes",
+    });
+    expect(mockReply.redirect).toHaveBeenCalledWith(
+      "/reset-delete/security-code-entered-exceeded",
+    );
+    expect(result).toBe(mockReply);
+  });
+
+  it("should send lockedOutSecurityCodeRequestedTooManyTimes event and redirect when BlockedForEmailVerificationCodes", async () => {
+    mockSendOtpChallenge.mockResolvedValue({
+      success: false,
+      error: "BlockedForEmailVerificationCodes",
+    });
+
+    const result = await sharedSendOtpHandler(
+      mockRequest as FastifyRequest,
+      mockReply as FastifyReply,
+    );
+
+    expect(
+      mockReply.journeyStates?.["account-delete"]?.send,
+    ).toHaveBeenCalledWith({
+      type: "lockedOutSecurityCodeRequestedTooManyTimes",
+    });
+    expect(mockReply.redirect).toHaveBeenCalledWith(
+      "/reset-delete/security-code-requested-too-many-times",
+    );
+    expect(result).toBe(mockReply);
+  });
+
+  it("should throw when sendOtpChallenge returns an unhandled error", async () => {
+    mockSendOtpChallenge.mockResolvedValue({
+      success: false,
+      error: "AccountManagementApiUnexpectedError",
+    });
+
+    await expect(
+      sharedSendOtpHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      ),
+    ).rejects.toThrow("AccountManagementApiUnexpectedError");
+  });
+
+  it("should throw if session claims are not available", async () => {
+    delete mockRequest.session;
+
+    await expect(
+      sharedSendOtpHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("should throw if access token is not available", async () => {
+    // @ts-expect-error
+    delete mockRequest.session.claims.account_management_api_access_token;
+
+    await expect(
+      sharedSendOtpHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("should throw if account-delete journey state is not available", async () => {
+    mockReply.journeyStates = {};
+
+    await expect(
+      sharedSendOtpHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("should throw if journey states are not available", async () => {
+    delete mockReply.journeyStates;
+
+    await expect(
+      sharedSendOtpHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/solutions/frontend/src/journeys/account-delete/utils/sharedSendOtpHandler.ts
+++ b/solutions/frontend/src/journeys/account-delete/utils/sharedSendOtpHandler.ts
@@ -1,0 +1,53 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import assert from "node:assert";
+import { AccountManagementApiClient } from "../../../utils/accountManagementApiClient.js";
+import { paths } from "../../../utils/paths.js";
+
+export async function sharedSendOtpHandler(
+  request: FastifyRequest,
+  reply: FastifyReply,
+) {
+  assert.ok(request.session.claims);
+  assert.ok(request.session.claims.account_management_api_access_token);
+  assert.ok(reply.journeyStates?.["account-delete"]);
+
+  const accountManagementApiClient = new AccountManagementApiClient(
+    request.session.claims.account_management_api_access_token,
+    request.awsLambda?.event,
+  );
+
+  const result = await accountManagementApiClient.sendOtpChallenge(
+    request.session.claims.public_sub,
+  );
+
+  if (!result.success) {
+    if (result.error === "TooManyEmailCodesEntered") {
+      reply.journeyStates["account-delete"].send({
+        type: "lockedOutSecurityCodeEnteredTooManyTimes",
+      });
+      reply.redirect(
+        paths.journeys["account-delete"]
+          .LOCKED_OUT_SECURITY_CODE_ENTERED_TOO_MANY_TIMES
+          .lockedOutSecurityCodeEnteredTooManyTimes.path,
+      );
+      return reply;
+    } else if (result.error === "BlockedForEmailVerificationCodes") {
+      reply.journeyStates["account-delete"].send({
+        type: "lockedOutSecurityCodeRequestedTooManyTimes",
+      });
+      reply.redirect(
+        paths.journeys["account-delete"]
+          .LOCKED_OUT_SECURITY_CODE_REQUESTED_TOO_MANY_TIMES
+          .lockedOutSecurityCodeRequestedTooManyTimes.path,
+      );
+      return reply;
+    }
+
+    throw new Error(result.error);
+  }
+
+  reply.redirect(
+    paths.journeys["account-delete"].EMAIL_NOT_VERIFIED.verifyEmailAddress.path,
+  );
+  return reply;
+}

--- a/solutions/frontend/src/journeys/utils/journeyActions.ts
+++ b/solutions/frontend/src/journeys/utils/journeyActions.ts
@@ -151,7 +151,7 @@ export const startJourneyAction = async <
   );
 
   if (!inProgressActionExists) {
-    const startedAt = new Date().getTime();
+    const startedAt = Date.now();
 
     request.session.journeyActions.push({
       ...action,


### PR DESCRIPTION
Extract shared OTP sending logic into `sharedSendOtpHandler`

The OTP sending logic that was duplicated across `introduction.ts` and `resendEmailVerificationCode.ts` has been extracted into a shared utility at `journeys/account-delete/utils/sharedSendOtpHandler.ts`.

- `introduction.ts` — removed inline OTP logic, now delegates to `sharedSendOtpHandler`
- `resendEmailVerificationCode.ts` — previously delegated to `introductionPostHandler`, now delegates directly to `sharedSendOtpHandler`
- Tests for both handlers updated to mock `sharedSendOtpHandler` rather than testing its internal behaviour (OTP error cases, session/token guards), which are covered by `sharedSendOtpHandler.test.ts`