### PR TITLE
OLH-4460: set webauthn timeout to session length

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -146,7 +146,8 @@ describe("passkey-create handlers", () => {
     mockRequest = {
       session: {
         claims: mockClaims,
-      } as FastifySessionObject,
+        expires: Math.floor(Date.now() / 1000) + 3600,
+      } as unknown as FastifySessionObject,
       body: {},
       log: {
         warn: vi.fn(),
@@ -344,6 +345,44 @@ describe("passkey-create handlers", () => {
           contentId: "e71140bc-bd4d-4ea2-9716-5bbb36c696dd",
         }),
       );
+    });
+
+    it("should set timeout to remaining session time", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+      const now = Math.floor(Date.now() / 1000);
+      // @ts-expect-error
+      mockRequest.session.expires = now + 300;
+
+      await getHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      );
+
+      expect(mockGenerateRegistrationOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ timeout: 300 }),
+      );
+
+      vi.useRealTimers();
+    });
+
+    it("should clamp timeout to 0 when session has already expired", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+      const now = Math.floor(Date.now() / 1000);
+      // @ts-expect-error
+      mockRequest.session.expires = now - 60;
+
+      await getHandler(
+        mockRequest as FastifyRequest,
+        mockReply as FastifyReply,
+      );
+
+      expect(mockGenerateRegistrationOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ timeout: 0 }),
+      );
+
+      vi.useRealTimers();
     });
 
     it("should fetch existing passkeys and exclude them", async () => {

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -347,7 +347,7 @@ describe("passkey-create handlers", () => {
       );
     });
 
-    it("should set timeout to remaining session time", async () => {
+    it("should set timeout to remaining session time minus the completion buffer", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
       const now = Math.floor(Date.now() / 1000);
@@ -360,13 +360,13 @@ describe("passkey-create handlers", () => {
       );
 
       expect(mockGenerateRegistrationOptions).toHaveBeenCalledWith(
-        expect.objectContaining({ timeout: 300_000 }),
+        expect.objectContaining({ timeout: 295_000 }),
       );
 
       vi.useRealTimers();
     });
 
-    it("should clamp timeout to 0 when session has already expired", async () => {
+    it("should clamp timeout to 1 when session has already expired", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
       const now = Math.floor(Date.now() / 1000);
@@ -379,7 +379,7 @@ describe("passkey-create handlers", () => {
       );
 
       expect(mockGenerateRegistrationOptions).toHaveBeenCalledWith(
-        expect.objectContaining({ timeout: 0 }),
+        expect.objectContaining({ timeout: 1 }),
       );
 
       vi.useRealTimers();

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -360,7 +360,7 @@ describe("passkey-create handlers", () => {
       );
 
       expect(mockGenerateRegistrationOptions).toHaveBeenCalledWith(
-        expect.objectContaining({ timeout: 300 }),
+        expect.objectContaining({ timeout: 300_000 }),
       );
 
       vi.useRealTimers();

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -65,6 +65,8 @@ const setRegistrationOptions = async (
   assert.ok(process.env["PASSKEYS_RP_NAME"]);
   assert.ok(request.session.expires);
 
+  const timeoutBufferToAllowCompletion = 5000;
+
   const registrationOptions = await generateRegistrationOptions({
     rpName: process.env["PASSKEYS_RP_NAME"],
     rpID: process.env["PASSKEYS_RP_ID"],
@@ -79,7 +81,12 @@ const setRegistrationOptions = async (
     excludeCredentials: idsOfCredentialsToExclude.map((id) => ({
       id,
     })),
-    timeout: Math.max(request.session.expires * 1000 - Date.now(), 0),
+    timeout: Math.max(
+      request.session.expires * 1000 -
+        timeoutBufferToAllowCompletion -
+        Date.now(),
+      1, // 1 not 0, just in case some authenticators interpret 0 as unlimited
+    ),
   });
 
   reply.journeyStates["passkey-create"].send({

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -63,6 +63,7 @@ const setRegistrationOptions = async (
   assert.ok(reply.journeyStates?.["passkey-create"]);
   assert.ok(process.env["PASSKEYS_RP_ID"]);
   assert.ok(process.env["PASSKEYS_RP_NAME"]);
+  assert.ok(request.session.expires);
 
   const registrationOptions = await generateRegistrationOptions({
     rpName: process.env["PASSKEYS_RP_NAME"],
@@ -78,6 +79,10 @@ const setRegistrationOptions = async (
     excludeCredentials: idsOfCredentialsToExclude.map((id) => ({
       id,
     })),
+    timeout: Math.max(
+      request.session.expires - Math.floor(Date.now() / 1000),
+      0,
+    ),
   });
 
   reply.journeyStates["passkey-create"].send({

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -65,8 +65,6 @@ const setRegistrationOptions = async (
   assert.ok(process.env["PASSKEYS_RP_NAME"]);
   assert.ok(request.session.expires);
 
-  const timeoutBufferToAllowCompletion = 5000;
-
   const registrationOptions = await generateRegistrationOptions({
     rpName: process.env["PASSKEYS_RP_NAME"],
     rpID: process.env["PASSKEYS_RP_ID"],
@@ -83,7 +81,7 @@ const setRegistrationOptions = async (
     })),
     timeout: Math.max(
       request.session.expires * 1000 -
-        timeoutBufferToAllowCompletion -
+        5000 - // Buffer to allow enough time for the request to be sent after the client registration ceremony
         Date.now(),
       1, // 1 not 0, just in case some authenticators interpret 0 as unlimited
     ),

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -79,10 +79,9 @@ const setRegistrationOptions = async (
     excludeCredentials: idsOfCredentialsToExclude.map((id) => ({
       id,
     })),
-    timeout: Math.max(
-      request.session.expires - Math.floor(Date.now() / 1000),
-      0,
-    ),
+    timeout:
+      Math.max(request.session.expires - Math.floor(Date.now() / 1000), 0) *
+      1000,
   });
 
   reply.journeyStates["passkey-create"].send({

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -79,9 +79,7 @@ const setRegistrationOptions = async (
     excludeCredentials: idsOfCredentialsToExclude.map((id) => ({
       id,
     })),
-    timeout:
-      Math.max(request.session.expires - Math.floor(Date.now() / 1000), 0) *
-      1000,
+    timeout: Math.max(request.session.expires * 1000 - Date.now(), 0),
   });
 
   reply.journeyStates["passkey-create"].send({

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -65,6 +65,8 @@ const setRegistrationOptions = async (
   assert.ok(process.env["PASSKEYS_RP_NAME"]);
   assert.ok(request.session.expires);
 
+  const timeoutBuffer = 5000; // Buffer to allow enough time for the registration to be completed
+
   const registrationOptions = await generateRegistrationOptions({
     rpName: process.env["PASSKEYS_RP_NAME"],
     rpID: process.env["PASSKEYS_RP_ID"],
@@ -80,9 +82,7 @@ const setRegistrationOptions = async (
       id,
     })),
     timeout: Math.max(
-      request.session.expires * 1000 -
-        5000 - // Buffer to allow enough time for the request to be sent after the client registration ceremony
-        Date.now(),
+      request.session.expires * 1000 - timeoutBuffer - Date.now(),
       1, // 1 not 0, just in case some authenticators interpret 0 as unlimited
     ),
   });


### PR DESCRIPTION
Updates the WebAuthn timeout to be the session length minus a 5 second buffer for the registration to complete. This helps to ensure that the native UI is not automatically dismissed whilst the user is still using it.