### PR TITLE
OLH-4459: make page inert on passkey creation submission

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/templates/create.njk
+++ b/solutions/frontend/src/journeys/passkey-create/templates/create.njk
@@ -129,6 +129,8 @@
       }
     }
 
+    document.body.inert = true;
+
     verifyPasskeyForm.submit();
   }
 


### PR DESCRIPTION
Makes the whole page inert when the create passkey form is submitted in order to prevent further user interaction with the page.