### PR TITLE
OLH-4443: track sign out with a navigtion event

### DIFF
--- a/solutions/frontend/src/templates/layout/header.njk
+++ b/solutions/frontend/src/templates/layout/header.njk
@@ -58,7 +58,7 @@
                 {% for key, value in signOutUrlQueryParams %}
                   <input type="hidden" name="{{ key }}" value="{{ value }}">
                 {% endfor %}
-                <button class="account-header-navigation__button" type="submit"><span class="govuk-!-font-weight-bold account-header-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
+                <button data-nav="true" data-link="{{ signOutUrl }}" class="account-header-navigation__button" type="submit"><span class="govuk-!-font-weight-bold account-header-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
               </form>              
             </nav>
           </div>


### PR DESCRIPTION
Adds the necessary attributes to the sign out button so that clicking it sends an analytics `navigation` event.