### PR TITLE
OLH-4443: remove span from sign out button

### DIFF
--- a/solutions/frontend/src/static/application.scss
+++ b/solutions/frontend/src/static/application.scss
@@ -84,20 +84,14 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
   background-color: transparent;
   padding: 0;
   margin: 0;
+  @include govuk-font($size: 16, $weight: bold);
+  color: govuk-colour("white");
+  @include govuk-link-style-inverse;
 
   &:focus {
     outline: none;
-    span {
-      @include govuk-focused-text;
-    }
+    @include govuk-focused-text;
   }
-}
-
-/* Specific styles for .account-header-navigation__button */
-.account-header-navigation__button-content {
-  @include govuk-font($size: 16);
-  color: govuk-colour("white");
-  @include govuk-link-style-inverse;
 
   &:not(:hover) {
     text-decoration: none;
@@ -110,10 +104,6 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
     @if $govuk-link-underline-offset {
       text-underline-offset: $govuk-link-underline-offset;
     }
-  }
-
-  &:focus {
-    @include govuk-focused-text;
   }
 }
 

--- a/solutions/frontend/src/templates/layout/header.njk
+++ b/solutions/frontend/src/templates/layout/header.njk
@@ -58,7 +58,7 @@
                 {% for key, value in signOutUrlQueryParams %}
                   <input type="hidden" name="{{ key }}" value="{{ value }}">
                 {% endfor %}
-                <button data-nav="true" data-link="{{ signOutUrl }}" class="account-header-navigation__button" type="submit"><span class="govuk-!-font-weight-bold account-header-navigation__button-content">{{ 'general.header.signOutLink' | translate }}</span></button>
+                <button data-nav="true" data-link="{{ signOutUrl }}" class="account-header-navigation__button" type="submit">{{ 'general.header.signOutLink' | translate }}</button>
               </form>              
             </nav>
           </div>


### PR DESCRIPTION
Removes the span from inside the sign out button and styles the button directly. This is necessary because the analytics library won't fire navigation events on buttons which contain child elements.