### PR TITLE
BAU: Sign out link double underline fix

### DIFF
--- a/solutions/frontend/src/static/application.scss
+++ b/solutions/frontend/src/static/application.scss
@@ -88,11 +88,6 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
   color: govuk-colour("white");
   @include govuk-link-style-inverse;
 
-  &:focus {
-    outline: none;
-    @include govuk-focused-text;
-  }
-
   &:not(:hover) {
     text-decoration: none;
   }
@@ -104,6 +99,11 @@ $nav-button-padding-bottom: $nav-link-padding + $nav-link-outline-thickness;
     @if $govuk-link-underline-offset {
       text-underline-offset: $govuk-link-underline-offset;
     }
+  }
+
+  &:focus {
+    outline: none;
+    @include govuk-focused-text;
   }
 }
 


### PR DESCRIPTION
This is applying the same fix as https://github.com/govuk-one-login/di-account-management-frontend/pull/3103

I haven't actually tested that the same issue is happening on AMC but it might be safe to assume that it is seeing how this code is identical. 