### PR TITLE
BAU: expose signing key in JWKS

### DIFF
--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -728,6 +728,7 @@ Resources:
         Variables:
           BUCKET_NAME: !Ref JWKSStoreBucket
           JAR_RSA_ENCRYPTION_KEY_ALIAS: !Ref JARRSAEncryptionKeyAlias
+          JWT_SIGNING_KEY_ALIAS: !Ref JWTSigningKeyAlias
       Policies:
         - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
         - Statement:
@@ -735,7 +736,9 @@ Resources:
               Action:
                 - kms:GetPublicKey
                 - kms:DescribeKey
-              Resource: !GetAtt JARRSAEncryptionKey.Arn
+              Resource:
+                - !GetAtt JARRSAEncryptionKey.Arn
+                - !GetAtt JWTSigningKey.Arn
             - Effect: Allow
               Action:
                 - kms:GenerateDataKey

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -785,7 +785,7 @@ Resources:
     Type: AWS::CloudFormation::CustomResource
     Properties:
       ServiceToken: !GetAtt JwksGeneratorLambda.Arn
-      ForceUpdate: !Ref JwksGeneratorLambda
+      ForceUpdate: !Ref JwksGeneratorLambda.Version
 
   AuthCodeTable:
     Type: AWS::DynamoDB::Table

--- a/solutions/core/src/lambda/jwks-creator.test.ts
+++ b/solutions/core/src/lambda/jwks-creator.test.ts
@@ -44,6 +44,7 @@ vi.mock(import("../../../commons/utils/awsClient/s3Client/index.js"), () => ({
 // @ts-expect-error
 vi.mock(import("../../../commons/utils/constants.js"), () => ({
   jarKeyEncryptionAlgorithm: "RSA-OAEP-256",
+  jwtSigningAlgorithm: "ES256",
 }));
 
 vi.mock(import("jose"), () => ({
@@ -104,20 +105,26 @@ describe("handler", () => {
     mockFetch.mockReset();
     process.env["BUCKET_NAME"] = "test-bucket";
     process.env["JAR_RSA_ENCRYPTION_KEY_ALIAS"] = "alias/test-key";
+    process.env["JWT_SIGNING_KEY_ALIAS"] = "alias/test-signing-key";
     mockFetch.mockResolvedValue({ ok: true, statusText: "OK" });
   });
 
   it("successfully generates JWKS and uploads to S3 on Create", async () => {
     const fakePublicKey = new Uint8Array([1, 2, 3, 4]);
     const fakeCryptoKey = { fake: true } as unknown as CryptoKey;
-    const fakeJwk = { kty: "RSA" };
+    const fakeEncJwk = { kty: "RSA" };
+    const fakeSigJwk = { kty: "EC" };
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
-    mockDescribeKey.mockResolvedValueOnce({
-      KeyMetadata: { KeyId: "test-key-id" },
-    });
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockDescribeKey
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-key-id" } })
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-signing-key-id" } });
     (importSPKI as unknown as MockInstance).mockResolvedValue(fakeCryptoKey);
-    (exportJWK as unknown as MockInstance).mockResolvedValue(fakeJwk);
+    (exportJWK as unknown as MockInstance)
+      .mockResolvedValueOnce(fakeEncJwk)
+      .mockResolvedValueOnce(fakeSigJwk);
     mockPutObject.mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
 
     const event = createEvent("Create");
@@ -126,14 +133,28 @@ describe("handler", () => {
     expect(mockGetPublicKey).toHaveBeenCalledWith({
       KeyId: "alias/test-key",
     });
+    expect(mockGetPublicKey).toHaveBeenCalledWith({
+      KeyId: "alias/test-signing-key",
+    });
     expect(mockDescribeKey).toHaveBeenCalledWith({
       KeyId: "alias/test-key",
+    });
+    expect(mockDescribeKey).toHaveBeenCalledWith({
+      KeyId: "alias/test-signing-key",
     });
     expect(mockPutObject).toHaveBeenCalledWith({
       Bucket: "test-bucket",
       Key: "jwks.json",
       Body: expect.stringMatching(
         /"kid":"test-key-id".*"alg":"RSA-OAEP-256".*"use":"enc"/,
+      ),
+      ContentType: "application/json",
+    });
+    expect(mockPutObject).toHaveBeenCalledWith({
+      Bucket: "test-bucket",
+      Key: "jwks.json",
+      Body: expect.stringMatching(
+        /"kid":"test-signing-key-id".*"alg":"ES256".*"use":"sig"/,
       ),
       ContentType: "application/json",
     });
@@ -150,14 +171,19 @@ describe("handler", () => {
   it("successfully generates JWKS and uploads to S3 on Update", async () => {
     const fakePublicKey = new Uint8Array([1, 2, 3, 4]);
     const fakeCryptoKey = { fake: true } as unknown as CryptoKey;
-    const fakeJwk = { kty: "RSA" };
+    const fakeEncJwk = { kty: "RSA" };
+    const fakeSigJwk = { kty: "EC" };
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
-    mockDescribeKey.mockResolvedValueOnce({
-      KeyMetadata: { KeyId: "test-key-id" },
-    });
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockDescribeKey
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-key-id" } })
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-signing-key-id" } });
     (importSPKI as unknown as MockInstance).mockResolvedValue(fakeCryptoKey);
-    (exportJWK as unknown as MockInstance).mockResolvedValue(fakeJwk);
+    (exportJWK as unknown as MockInstance)
+      .mockResolvedValueOnce(fakeEncJwk)
+      .mockResolvedValueOnce(fakeSigJwk);
     mockPutObject.mockResolvedValueOnce({ $metadata: { httpStatusCode: 200 } });
 
     const event = createEvent("Update");
@@ -166,11 +192,22 @@ describe("handler", () => {
     expect(mockGetPublicKey).toHaveBeenCalledWith({
       KeyId: "alias/test-key",
     });
+    expect(mockGetPublicKey).toHaveBeenCalledWith({
+      KeyId: "alias/test-signing-key",
+    });
     expect(mockPutObject).toHaveBeenCalledWith({
       Bucket: "test-bucket",
       Key: "jwks.json",
       Body: expect.stringMatching(
         /"kid":"test-key-id".*"alg":"RSA-OAEP-256".*"use":"enc"/,
+      ),
+      ContentType: "application/json",
+    });
+    expect(mockPutObject).toHaveBeenCalledWith({
+      Bucket: "test-bucket",
+      Key: "jwks.json",
+      Body: expect.stringMatching(
+        /"kid":"test-signing-key-id".*"alg":"ES256".*"use":"sig"/,
       ),
       ContentType: "application/json",
     });
@@ -203,10 +240,12 @@ describe("handler", () => {
     const fakeCryptoKey = { fake: true } as unknown as CryptoKey;
     const fakeJwk = { kty: "RSA" };
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
-    mockDescribeKey.mockResolvedValueOnce({
-      KeyMetadata: { KeyId: "test-key-id" },
-    });
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockDescribeKey
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-key-id" } })
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-signing-key-id" } });
     (importSPKI as unknown as MockInstance).mockResolvedValue(fakeCryptoKey);
     (exportJWK as unknown as MockInstance).mockResolvedValue(fakeJwk);
 
@@ -239,8 +278,24 @@ describe("handler", () => {
     );
   });
 
+  it("sends FAILED response if JWT_SIGNING_KEY_ALIAS is not set", async () => {
+    delete process.env["JWT_SIGNING_KEY_ALIAS"];
+
+    const event = createEvent("Create");
+    await handler(event, context);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      event.ResponseURL,
+      expect.objectContaining({
+        method: "PUT",
+        body: expect.stringContaining('"Status":"FAILED"'),
+      }),
+    );
+  });
+
   it("sends FAILED response if public key is missing", async () => {
     mockGetPublicKey.mockResolvedValueOnce({ PublicKey: undefined });
+    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: new Uint8Array([1]) });
 
     const event = createEvent("Create");
     await handler(event, context);
@@ -257,8 +312,11 @@ describe("handler", () => {
   it("sends FAILED response if key metadata is missing", async () => {
     const fakePublicKey = new Uint8Array([1, 2, 3, 4]);
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
     mockDescribeKey.mockResolvedValueOnce({ KeyMetadata: undefined });
+    mockDescribeKey.mockResolvedValueOnce({ KeyMetadata: { KeyId: "id" } });
 
     const event = createEvent("Create");
     await handler(event, context);
@@ -277,8 +335,12 @@ describe("handler", () => {
     const fakeCryptoKey = { fake: true } as unknown as CryptoKey;
     const fakeJwk = { kty: "RSA" };
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
-    mockDescribeKey.mockResolvedValueOnce({ KeyMetadata: {} }); // Missing KeyId
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockDescribeKey
+      .mockResolvedValueOnce({ KeyMetadata: {} }) // Missing KeyId
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "id" } });
     (importSPKI as unknown as MockInstance).mockResolvedValue(fakeCryptoKey);
     (exportJWK as unknown as MockInstance).mockResolvedValue(fakeJwk);
 
@@ -296,6 +358,7 @@ describe("handler", () => {
 
   it("sends FAILED response on KMS getPublicKey error", async () => {
     mockGetPublicKey.mockRejectedValueOnce(new Error("KMS failure"));
+    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: new Uint8Array([1]) });
 
     const event = createEvent("Create");
     await handler(event, context);
@@ -312,8 +375,11 @@ describe("handler", () => {
   it("sends FAILED response on KMS describeKey error", async () => {
     const fakePublicKey = new Uint8Array([1, 2, 3, 4]);
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
     mockDescribeKey.mockRejectedValueOnce(new Error("KMS describe failure"));
+    mockDescribeKey.mockResolvedValueOnce({ KeyMetadata: { KeyId: "id" } });
 
     const event = createEvent("Create");
     await handler(event, context);
@@ -330,10 +396,12 @@ describe("handler", () => {
   it("sends FAILED response on JOSE operations error", async () => {
     const fakePublicKey = new Uint8Array([1, 2, 3, 4]);
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
-    mockDescribeKey.mockResolvedValueOnce({
-      KeyMetadata: { KeyId: "test-key-id" },
-    });
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockDescribeKey
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-key-id" } })
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-signing-key-id" } });
     (importSPKI as unknown as MockInstance).mockRejectedValue(
       new Error("JOSE failure"),
     );
@@ -355,10 +423,12 @@ describe("handler", () => {
     const fakeCryptoKey = { fake: true } as unknown as CryptoKey;
     const fakeJwk = { kty: "RSA" };
 
-    mockGetPublicKey.mockResolvedValueOnce({ PublicKey: fakePublicKey });
-    mockDescribeKey.mockResolvedValueOnce({
-      KeyMetadata: { KeyId: "test-key-id" },
-    });
+    mockGetPublicKey
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey })
+      .mockResolvedValueOnce({ PublicKey: fakePublicKey });
+    mockDescribeKey
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-key-id" } })
+      .mockResolvedValueOnce({ KeyMetadata: { KeyId: "test-signing-key-id" } });
     (importSPKI as unknown as MockInstance).mockResolvedValue(fakeCryptoKey);
     (exportJWK as unknown as MockInstance).mockResolvedValue(fakeJwk);
     mockPutObject.mockRejectedValueOnce(new Error("S3 upload failed"));

--- a/solutions/core/src/lambda/jwks-creator.ts
+++ b/solutions/core/src/lambda/jwks-creator.ts
@@ -5,7 +5,10 @@ import { createPublicKey } from "node:crypto";
 import assert from "node:assert";
 import { getS3Client } from "../../../commons/utils/awsClient/s3Client/index.js";
 import { getKmsClient } from "../../../commons/utils/awsClient/kmsClient/index.js";
-import { jarKeyEncryptionAlgorithm } from "../../../commons/utils/constants.js";
+import {
+  jarKeyEncryptionAlgorithm,
+  jwtSigningAlgorithm,
+} from "../../../commons/utils/constants.js";
 import { logger } from "../../../commons/utils/logger/index.js";
 
 export const handler = async (
@@ -20,10 +23,25 @@ export const handler = async (
         process.env["JAR_RSA_ENCRYPTION_KEY_ALIAS"],
         "JAR_RSA_ENCRYPTION_KEY_ALIAS not set",
       );
-
-      const jwks = await generateJwksFromKmsPublicKey(
-        process.env["JAR_RSA_ENCRYPTION_KEY_ALIAS"],
+      assert.ok(
+        process.env["JWT_SIGNING_KEY_ALIAS"],
+        "JWT_SIGNING_KEY_ALIAS not set",
       );
+
+      const [encryptionJwk, signingJwk] = await Promise.all([
+        getJwkFromKms(
+          process.env["JAR_RSA_ENCRYPTION_KEY_ALIAS"],
+          jarKeyEncryptionAlgorithm,
+          "enc",
+        ),
+        getJwkFromKms(
+          process.env["JWT_SIGNING_KEY_ALIAS"],
+          jwtSigningAlgorithm,
+          "sig",
+        ),
+      ]);
+
+      const jwks = { keys: [encryptionJwk, signingJwk] };
 
       await putContentToS3(JSON.stringify(jwks));
     }
@@ -66,66 +84,60 @@ async function sendResponse(
   }
 }
 
-async function generateJwksFromKmsPublicKey(
+async function getJwkFromKms(
   keyAlias: string,
-): Promise<{ keys: JWK[] }> {
-  try {
-    logger.info("Getting Public Key using Alias: " + keyAlias);
+  algorithm: string,
+  use: "enc" | "sig",
+): Promise<JWK> {
+  logger.info("Getting Public Key using Alias: " + keyAlias);
 
-    const kmsClient = getKmsClient();
+  const kmsClient = getKmsClient();
 
-    const { PublicKey } = await kmsClient.getPublicKey({
-      KeyId: keyAlias,
-    });
+  const { PublicKey } = await kmsClient.getPublicKey({
+    KeyId: keyAlias,
+  });
 
-    if (!PublicKey) {
-      throw new Error(`Public key not found for KMS Key Alias: ${keyAlias}`);
-    }
+  if (!PublicKey) {
+    throw new Error(`Public key not found for KMS Key Alias: ${keyAlias}`);
+  }
 
-    logger.info("Public key material", { PublicKey });
+  logger.info("Public key material", { PublicKey });
 
-    const { KeyMetadata } = await kmsClient.describeKey({
-      KeyId: keyAlias,
-    });
+  const { KeyMetadata } = await kmsClient.describeKey({
+    KeyId: keyAlias,
+  });
 
-    if (!KeyMetadata) {
-      throw new Error(`Key ID not found for KMS Key Alias: ${keyAlias}`);
-    }
+  if (!KeyMetadata) {
+    throw new Error(`Key ID not found for KMS Key Alias: ${keyAlias}`);
+  }
 
-    logger.info("Key Metadata", { KeyMetadata });
+  logger.info("Key Metadata", { KeyMetadata });
 
-    const pem = createPublicKey({
-      key: Buffer.from(PublicKey),
-      format: "der",
+  const pem = createPublicKey({
+    key: Buffer.from(PublicKey),
+    format: "der",
+    type: "spki",
+  })
+    .export({
+      format: "pem",
       type: "spki",
     })
-      .export({
-        format: "pem",
-        type: "spki",
-      })
-      .toString();
+    .toString();
 
-    logger.info("Created PEM", { pem });
+  logger.info("Created PEM", { pem });
 
-    const cryptoKey = await importSPKI(pem, jarKeyEncryptionAlgorithm);
-    const jwk = await exportJWK(cryptoKey);
+  const cryptoKey = await importSPKI(pem, algorithm);
+  const jwk = await exportJWK(cryptoKey);
 
-    assert.ok(KeyMetadata.KeyId, "KeyMetadata.KeyId not defined");
+  assert.ok(KeyMetadata.KeyId, "KeyMetadata.KeyId not defined");
 
-    jwk.kid = KeyMetadata.KeyId;
-    jwk.alg = jarKeyEncryptionAlgorithm;
-    jwk.use = "enc";
+  jwk.kid = KeyMetadata.KeyId;
+  jwk.alg = algorithm;
+  jwk.use = use;
 
-    logger.info("JWK", { jwk });
+  logger.info("JWK", { jwk });
 
-    return {
-      keys: [jwk],
-    };
-  } catch (error) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    logger.error("Error generating JWKS from KMS public key:", error as Error);
-    throw error;
-  }
+  return jwk;
 }
 
 async function putContentToS3(content: string) {


### PR DESCRIPTION
Adds the public key from the JWT signing key pair to our JWKS. This allows clients to verify access tokens if they want to, and is just general good practice.