### PR TITLE
OLH-4461: Switch to official zizmor-pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,16 +69,10 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
-  - repo: local
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: e3eebf65325ccc992422292cb7a4baee967cf815 # pragma: allowlist secret
     hooks:
-      - id: check-gh-actions
-        name: Check GitHub Actions
-        entry: npm run check-gh-actions
-        language: system
-        exclude: .*
-        always_run: true
-        pass_filenames: false
-        stages: [pre-commit]
+      - id: zizmor
 
   - repo: local
     hooks:


### PR DESCRIPTION
Replaces the system `zizmor` pre-commit hook (which required `zizmor` installed via `Brewfile`) with the official `zizmorcore/zizmor-pre-commit` managed hook. Pre-commit now installs `zizmor` automatically.

This is part of a process to standardise our linting and GitHub actions setup across Home owned repos.