### PR TITLE
OLH-3314: update Dynatrace lambda layer to the latest version

### DIFF
--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -283,7 +283,7 @@ Globals:
       - !If [
           IsLocal,
           !Ref AWS::NoValue,
-          "arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_313_2_20250404-043044_with_collector_nodejs:1",
+          "arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_329_73_20260123-140641_with_collector_nodejs_arm:1",
         ]
     CodeSigningConfigArn: !If
       - UseCodeSigning


### PR DESCRIPTION
Updates the Dynatrace lambda layer to the latest version. This has been deployed to dev and everything is working as expected.