### PR TITLE
OLH-4461: Run pre-commit in check.yaml

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -57,35 +57,15 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build:all
 
-      - name: Check types
-        run: npm run check-types
+      - name: Cache pre-commit environments
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: pre-commit-
 
-      - name: ESLint
-        run: npm run eslint
-
-      - name: Lint Terraform
-        run: npm run tflint
-
-      - name: SAM validate
-        run: npm run sam-validate
-
-      - name: Lint CloudFormation
-        run: npm run cfnlint
-
-      - name: Check formatting
-        run: npm run format
-
-      - name: Knip
-        run: npm run knip
-
-      - name: Validate config
-        run: npm run config:validate
-
-      - name: Validate API Specs
-        run: npm run api-specs:validate
-
-      - name: Detect secrets
-        run: npm run detect-secrets-ci
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
 
       - name: Validate passkeys convenience metadata
         run: |

--- a/.github/workflows/requirements.in
+++ b/.github/workflows/requirements.in
@@ -1,1 +1,2 @@
 detect-secrets==1.5.0
+pre-commit==4.2.0

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -7,6 +7,9 @@
 certifi==2026.5.20 \
     --hash=sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897 \
     --hash=sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d
+cfgv==3.5.0 \
+    --hash=sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0 \
+    --hash=sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132
 charset-normalizer==3.4.7 \
     --hash=sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc \
     --hash=sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c \
@@ -140,9 +143,30 @@ charset-normalizer==3.4.7 \
 detect-secrets==1.5.0 \
     --hash=sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a \
     --hash=sha256:e24e7b9b5a35048c313e983f76c4bd09dad89f045ff059e354f9943bf45aa060
+distlib==0.4.3 \
+    --hash=sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b \
+    --hash=sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed
+filelock==3.30.2 \
+    --hash=sha256:1ea7c857465c897a4a6e64c1aace28ff6b83f5bc66c1c06ea148efa65bc2ec5d \
+    --hash=sha256:a64b58f75048ec39589983e97f5117163f822261dcb6ba843e098f05aac9663f
+identify==2.6.19 \
+    --hash=sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a \
+    --hash=sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842
 idna==3.16 \
     --hash=sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5 \
     --hash=sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d
+nodeenv==1.10.0 \
+    --hash=sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827 \
+    --hash=sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb
+platformdirs==4.10.0 \
+    --hash=sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7 \
+    --hash=sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a
+pre-commit==4.2.0 \
+    --hash=sha256:601283b9757afd87d40c4c4a9b2b5de9637a8ea02eaff7adc2d0fb4e04841146 \
+    --hash=sha256:a009ca7205f1eb497d10b845e52c838a98b6cdd2102a6c8e4540e94ee75c58bd
+python-discovery==1.4.4 \
+    --hash=sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3 \
+    --hash=sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \
@@ -223,3 +247,6 @@ requests==2.34.2 \
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+virtualenv==21.6.1 \
+    --hash=sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128 \
+    --hash=sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -2,4 +2,5 @@ plugin "aws" {
     enabled = true
     version = "0.48.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
+    signature = "pgp" # workaround for https://github.com/terraform-linters/tflint/issues/2594
 }

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -5,19 +5,6 @@
       "service-tag": "home",
       "quality-gates": [
         {
-          "check-types": [
-            "code style and linting",
-            "secret scanning",
-            "vulnerability detection"
-          ],
-          "provider": "GitHub",
-          "phase": "pre-merge",
-          "config": {
-            "file": ".pre-commit-config.yaml",
-            "name": "Pre-commit check"
-          }
-        },
-        {
           "check-types": ["unit", "new feature", "regression"],
           "provider": "GitHub",
           "phase": "pre-merge",


### PR DESCRIPTION
Replaces 10 individual lint steps in `check.yaml` with `pre-commit run --all-files`. `.pre-commit-config.yaml` is now the single source of truth for common linting rules locally and in GHA.
  
Removed individual steps (now covered by `pre-commit` hooks): `check-types`, `eslint`, `tflint`, `sam-validate`, `cfnlint`, `check-formatting`, `knip`, `validate-config`, `validate-api-specs`, `detect-secrets`.
  
Kept as separate steps (not suitable for pre-commit): `zizmor-action` (SARIF upload to Security tab), `passkey metadata validation` (requires submodule and rarely changes due to local changes), `checkov` (slow locally).
  
Also adds `pre-commit` to requirements.in for hash-pinned CI installation, and removes the `.pre-commit-config.yaml` entry from `quality-gate.manifest.json` (redundant with the check.yaml entry which now runs `pre-commit`).

See the `check` action on this PR has passed.
