### PR TITLE
OLH-4461: Standardise workflow naming

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Check
+name: Lint
 
 permissions: {}
 
@@ -7,7 +7,7 @@ on:
   merge_group:
 
 jobs:
-  check:
+  lint:
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/local-tests-integration.yaml
+++ b/.github/workflows/local-tests-integration.yaml
@@ -1,4 +1,4 @@
-name: Integration test
+name: Local tests (integration)
 
 permissions: {}
 
@@ -7,7 +7,7 @@ on:
   merge_group:
 
 jobs:
-  integration-test:
+  local-tests-integration:
     runs-on: ubuntu-latest
     permissions:
       packages: read

--- a/.github/workflows/local-tests-unit.yaml
+++ b/.github/workflows/local-tests-unit.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Local tests (unit)
 
 permissions: {}
 
@@ -7,7 +7,7 @@ on:
   merge_group:
 
 jobs:
-  test:
+  local-tests-unit:
     runs-on: ubuntu-latest
     permissions:
       packages: read

--- a/quality-gate.manifest.json
+++ b/quality-gate.manifest.json
@@ -9,9 +9,9 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/test.yaml",
-            "path": "jobs.test",
-            "name": "Test"
+            "file": ".github/workflows/local-tests-unit.yaml",
+            "path": "jobs.local-tests-unit",
+            "name": "Local tests (unit)"
           }
         },
         {
@@ -24,9 +24,9 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/check.yaml",
-            "path": "jobs.check",
-            "name": "Check"
+            "file": ".github/workflows/lint.yaml",
+            "path": "jobs.lint",
+            "name": "Lint"
           }
         },
         {
@@ -34,9 +34,9 @@
           "provider": "GitHub",
           "phase": "pre-merge",
           "config": {
-            "file": ".github/workflows/integration-test.yaml",
-            "path": "jobs.integration-test",
-            "name": "Integration test"
+            "file": ".github/workflows/local-tests-integration.yaml",
+            "path": "jobs.local-tests-integration",
+            "name": "Local tests (integration)"
           }
         },
         {
@@ -84,9 +84,9 @@
           "provider": "GitHub",
           "phase": "pre-upload",
           "config": {
-            "file": ".github/workflows/test.yaml",
-            "path": "jobs.test",
-            "name": "Test"
+            "file": ".github/workflows/local-tests-unit.yaml",
+            "path": "jobs.local-tests-unit",
+            "name": "Local tests (unit)"
           }
         }
       ]


### PR DESCRIPTION
### What changed:
  
1. Renamed `check.yaml` to `lint.yaml` (file, workflow name, and job ID)
2. Renamed test workflows for cross-repo consistency:
  - `test.yaml` → `local-tests-unit.yaml`
  - `integration-test.yaml` → `local-tests-integration.yaml`
  - These changes distinguish local tests to `deployed-tests.yaml` which will soon exist in https://github.com/govuk-one-login/di-account-management-backend
  
3. Updated `quality-gate.manifest.json` to reflect all renames
  
### Why did it change:
  
Consistent naming conventions across all three Home repos (account-components, backend, frontend). "Local tests" = runs self-contained in the GitHub runner.
 