### PR TITLE
BAU: fixes the indentation on the OpenAPI spec for accountInterventionsStatus

### DIFF
--- a/solutions/api/open-api-spec.yaml
+++ b/solutions/api/open-api-spec.yaml
@@ -245,12 +245,12 @@ paths:
                           error:
                             code: 1004
                             description: AccountHasInterventions
-                            accountInterventionsStatus:
-                              state:
-                                blocked: false
-                                suspended: true
-                                resetPassword: false
-                                reproveIdentity: true
+                          accountInterventionsStatus:
+                            state:
+                              blocked: false
+                              suspended: true
+                              resetPassword: false
+                              reproveIdentity: true
 
         "400":
           description: Bad request - invalid authorization header, access token, or outcome mismatch


### PR DESCRIPTION
Corrects the indentation in the OpenAPI spec so that `accountInterventionsStatus` appears at the correct level