### PR TITLE
BAU: fix fastify logging errors

### DIFF
--- a/solutions/commons/utils/fastify/logController/index.test.ts
+++ b/solutions/commons/utils/fastify/logController/index.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from "vitest";
+import { FastifyLogController } from "./index.js";
+
+describe("fastifyLogController", () => {
+  it("sets disableRequestLogging to true", () => {
+    const controller = new FastifyLogController();
+
+    expect(controller.disableRequestLogging).toBe(true);
+  });
+});

--- a/solutions/commons/utils/fastify/logController/index.ts
+++ b/solutions/commons/utils/fastify/logController/index.ts
@@ -1,0 +1,9 @@
+import { LogController } from "fastify";
+
+export class FastifyLogController extends LogController {
+  constructor() {
+    super({
+      disableRequestLogging: true,
+    });
+  }
+}

--- a/solutions/frontend/src/index.ts
+++ b/solutions/frontend/src/index.ts
@@ -42,6 +42,7 @@ import { FastifyPowertoolsLogger } from "../../commons/utils/fastify/powertoolsL
 import { resolveEnvVarToBool } from "../../commons/utils/resolveEnvVarToBool/index.js";
 import { simpleUnsuccessfulJourneyActionErrors } from "./journeys/utils/journeyActions.js";
 import { setAnalyticsForPath } from "./utils/setAnalyticsForPath/index.js";
+import { FastifyLogController } from "../../commons/utils/fastify/logController/index.js";
 
 await configureI18n({
   [Lang.English]: {
@@ -60,7 +61,7 @@ export const initFrontend = async function () {
   const fastify = Fastify.default({
     trustProxy: true, // Required as HTTPS is terminated before the Lambda
     loggerInstance: new FastifyPowertoolsLogger(),
-    disableRequestLogging: true,
+    logController: new FastifyLogController(),
   });
 
   fastify.addHook("onRequest", removeTrailingSlash);

--- a/solutions/stubs/src/index.ts
+++ b/solutions/stubs/src/index.ts
@@ -19,12 +19,13 @@ import { getEnvironment } from "../../commons/utils/getEnvironment/index.js";
 import { accountManagementApi } from "./accountManagementApi/index.js";
 import { accountDataApi } from "./accountDataApi/index.js";
 import { accountInterventionsServiceApi } from "./accountInterventionsServiceApi/index.js";
+import { FastifyLogController } from "../../commons/utils/fastify/logController/index.js";
 
 export const initStubs = async function () {
   const fastify = Fastify.default({
     trustProxy: true, // Required as HTTPS is terminated before the Lambda
     loggerInstance: new FastifyPowertoolsLogger(),
-    disableRequestLogging: true,
+    logController: new FastifyLogController(),
   });
 
   fastify.addHook("onRequest", removeTrailingSlash);


### PR DESCRIPTION
Fix to address these errors which are appearing in the logs:

> ERROR	(node:8) [FSTDEP023] FastifyDeprecation: disableRequestLogging option is deprecated. Use the logController option with disableRequestLogging or isLogDisabled override instead. The disableRequestLogging top-level option will be removed in `fastify@6`.