### PR TITLE
BAU: improve handling of undefined registration response

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
@@ -547,18 +547,28 @@ describe("passkey-create audit events", () => {
       );
     });
 
-    it("excludes passkey_enrolment_failure_reason when registrationResponse is undefined", async () => {
+    it("excludes passkey_enrolment_failure_reason and response info fields when registrationResponse is undefined", async () => {
       await sendPasskeyEnrolmentFailedAuditEvent(
         mockRequest as FastifyRequest,
         mockReply as FastifyReply,
         registrationOptions as PublicKeyCredentialCreationOptionsJSON,
       );
 
+      expect(mockExtractRegistrationResponseInfo).not.toHaveBeenCalled();
+
       const eventPayload = mockCreateEvent.mock.calls[0]?.[1];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(eventPayload.extensions.passkey).not.toHaveProperty(
         "passkey_enrolment_failure_reason",
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(eventPayload.extensions.passkey).not.toHaveProperty(
+        "passkey_aaguid",
+      );
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      expect(eventPayload.restricted.passkey).not.toHaveProperty(
+        "passkey_credential_id",
       );
     });
 

--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
@@ -114,21 +114,24 @@ const getBaseEventProps = (request: FastifyRequest, reply: FastifyReply) => {
 
 const buildEnrolmentEventPayload = (
   registrationOptions: PublicKeyCredentialCreationOptionsJSON,
-  registrationResponse: InferOutput<
+  registrationResponse?: InferOutput<
     typeof postBodySchema
   >["registrationResponse"],
 ) => {
-  const responseInfo = extractRegistrationResponseInfo(registrationResponse);
+  const responseInfo =
+    registrationResponse === undefined
+      ? undefined
+      : extractRegistrationResponseInfo(registrationResponse);
 
   return {
     responseInfo,
     extensions: {
-      ...buildResponseInfoPasskeyFields(responseInfo),
+      ...(responseInfo && buildResponseInfoPasskeyFields(responseInfo)),
       passkey_registration_request:
         buildRegistrationRequest(registrationOptions),
     },
     restricted: {
-      ...(responseInfo.credentialId !== undefined && {
+      ...(responseInfo?.credentialId !== undefined && {
         passkey_credential_id: responseInfo.credentialId,
       }),
       passkey_excluded_credentials:

--- a/solutions/frontend/src/journeys/passkey-create/utils/extractRegistrationResponseInfo/index.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/extractRegistrationResponseInfo/index.test.ts
@@ -352,23 +352,6 @@ describe("extractRegistrationResponseInfo", () => {
     );
   });
 
-  it("returns undefined when registrationResponse is undefined", () => {
-    const result = extractRegistrationResponseInfo(undefined);
-
-    expect(result).toStrictEqual({
-      credentialId: undefined,
-      aaguid: undefined,
-      counter: undefined,
-      credentialBackedUp: undefined,
-      userVerified: undefined,
-      publicKeyAlgorithm: undefined,
-      credentialDeviceType: undefined,
-      credentialTransports: undefined,
-      fmt: undefined,
-    });
-    expect(mockDecodeAttestationObject).not.toHaveBeenCalled();
-  });
-
   describe("error handling", () => {
     it("returns all undefined values when decodeAttestationObject throws", () => {
       setupMocks();

--- a/solutions/frontend/src/journeys/passkey-create/utils/extractRegistrationResponseInfo/index.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/extractRegistrationResponseInfo/index.ts
@@ -27,17 +27,6 @@ interface RegistrationResponseInfo {
   fmt: AttestationFormat | undefined;
 }
 
-const defaultReturnValue = {
-  credentialId: undefined,
-  aaguid: undefined,
-  counter: undefined,
-  credentialBackedUp: undefined,
-  userVerified: undefined,
-  publicKeyAlgorithm: undefined,
-  credentialDeviceType: undefined,
-  credentialTransports: undefined,
-  fmt: undefined,
-} as const;
 /*
 Unfortunately this function is required because SimpleWebAuthn does not
 provide a way get registration response info without first successfully
@@ -48,10 +37,6 @@ to extract it.
 export function extractRegistrationResponseInfo(
   registrationResponse: unknown,
 ): RegistrationResponseInfo {
-  if (registrationResponse === undefined) {
-    return defaultReturnValue;
-  }
-
   try {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     const response = (registrationResponse as RegistrationResponseJSON)
@@ -94,6 +79,16 @@ export function extractRegistrationResponseInfo(
     logger.error("Error extracting passkey registration response info", {
       error,
     });
-    return defaultReturnValue;
+    return {
+      credentialId: undefined,
+      aaguid: undefined,
+      counter: undefined,
+      credentialBackedUp: undefined,
+      userVerified: undefined,
+      publicKeyAlgorithm: undefined,
+      credentialDeviceType: undefined,
+      credentialTransports: undefined,
+      fmt: undefined,
+    };
   }
 }


### PR DESCRIPTION
The PR https://github.com/govuk-one-login/account-components/pull/1007 included changes for handling undefined passkey registration responses when building audit events. The changes work but in hindsight the guards are not in the best place. This PR moves the guard into a more sensible place.