### PR TITLE
BAU: cold start alarms

### DIFF
--- a/runbooks/api-alarms-runbook.md
+++ b/runbooks/api-alarms-runbook.md
@@ -104,18 +104,6 @@ These alarms may indicate a P3 incident. Out-of-hours escalation and support is 
 4. Check downstream service health (DynamoDB, KMS).
 5. Check whether a recent deployment correlates with the start of errors.
 
-### ApiJourneyOutcomeLambdaErrorsAlarm
-
-**What it means:** The Journey Outcome Lambda function is producing invocation errors (unhandled exceptions or timeouts).
-
-**Investigation steps:**
-
-1. Check the `amc-dashboard` CloudWatch dashboard.
-2. Check the Journey Outcome Lambda logs at `/aws/lambda/amc/ApiJourneyOutcomeLambda` for stack traces or timeout messages.
-3. Check Lambda metrics (duration, memory usage, concurrent executions) for resource exhaustion.
-4. Check downstream dependencies (e.g. DynamoDB, KMS) for availability issues.
-5. Check whether a recent deployment correlates with the start of errors.
-
 ### ApiTokenLambdaColdStartDurationAnomalyAlarm
 
 **What it means:** The p90 cold start duration (`InitDuration`) of the Token Lambda has exceeded the anomaly detection band — i.e. it is significantly higher than the ML-modelled baseline. This may indicate a dependency being initialised during cold starts is slower than usual, or that a recent deployment has increased initialisation time.

--- a/runbooks/api-alarms-runbook.md
+++ b/runbooks/api-alarms-runbook.md
@@ -7,8 +7,10 @@ This runbook covers the following second line production alarms for the Account 
 - [ApiApiGateway5XXErrorsAlarm](#apiapigateway5xxerrorsalarm)
 - [ApiTokenLambdaErrorsAlarm](#apitokenlambdaerrorsalarm)
 - [ApiTokenLambdaLogErrorAlarm](#apitokenlambdalogerroralarm)
+- [ApiTokenLambdaColdStartDurationAnomalyAlarm](#apitokenlambdacoldstartdurationanomalyalarm)
 - [ApiJourneyOutcomeLambdaErrorsAlarm](#apijourneyoutcomelambdaerrorsalarm)
 - [ApiJourneyOutcomeLambdaLogErrorAlarm](#apijourneyoutcomelambdalogerroralarm)
+- [ApiJourneyOutcomeLambdaColdStartDurationAnomalyAlarm](#apijourneyoutcomelambdacoldstartdurationanomalyalarm)
 
 These alarms are owned by the **Home team** in the **Accounts pod**.
 
@@ -114,6 +116,29 @@ These alarms may indicate a P3 incident. Out-of-hours escalation and support is 
 4. Check downstream dependencies (e.g. DynamoDB, KMS) for availability issues.
 5. Check whether a recent deployment correlates with the start of errors.
 
+### ApiTokenLambdaColdStartDurationAnomalyAlarm
+
+**What it means:** The p90 cold start duration (`InitDuration`) of the Token Lambda has exceeded the anomaly detection band — i.e. it is significantly higher than the ML-modelled baseline. This may indicate a dependency being initialised during cold starts is slower than usual, or that a recent deployment has increased initialisation time.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard — the "Token lambda cold start duration (p90) in milliseconds" widget shows the trend over time.
+2. Check whether a recent deployment correlates with the increase — a larger bundle size or new initialisation-time dependencies can increase cold start duration.
+3. Check Lambda metrics for memory pressure or CPU throttling which could slow initialisation.
+4. If cold start durations are consistently elevated after a deployment, consider whether the change can be optimised to reduce initialisation work.
+
+### ApiJourneyOutcomeLambdaErrorsAlarm
+
+**What it means:** The Journey Outcome Lambda function is producing invocation errors (unhandled exceptions or timeouts).
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard.
+2. Check the Journey Outcome Lambda logs at `/aws/lambda/amc/ApiJourneyOutcomeLambda` for stack traces or timeout messages.
+3. Check Lambda metrics (duration, memory usage, concurrent executions) for resource exhaustion.
+4. Check downstream dependencies (e.g. DynamoDB, KMS) for availability issues.
+5. Check whether a recent deployment correlates with the start of errors.
+
 ### ApiJourneyOutcomeLambdaLogErrorAlarm
 
 **What it means:** The Journey Outcome Lambda is logging ERROR or CRITICAL level messages at an elevated rate.
@@ -125,3 +150,14 @@ These alarms may indicate a P3 incident. Out-of-hours escalation and support is 
 3. Check whether errors relate to token validation or journey outcome retrieval.
 4. Check downstream service health (DynamoDB, KMS).
 5. Check whether a recent deployment correlates with the start of errors.
+
+### ApiJourneyOutcomeLambdaColdStartDurationAnomalyAlarm
+
+**What it means:** The p90 cold start duration (`InitDuration`) of the Journey Outcome Lambda has exceeded the anomaly detection band — i.e. it is significantly higher than the ML-modelled baseline. This may indicate a dependency being initialised during cold starts is slower than usual, or that a recent deployment has increased initialisation time.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard — the "Journey outcome lambda cold start duration (p90) in milliseconds" widget shows the trend over time.
+2. Check whether a recent deployment correlates with the increase — a larger bundle size or new initialisation-time dependencies can increase cold start duration.
+3. Check Lambda metrics for memory pressure or CPU throttling which could slow initialisation.
+4. If cold start durations are consistently elevated after a deployment, consider whether the change can be optimised to reduce initialisation work.

--- a/runbooks/frontend-alarms-runbook.md
+++ b/runbooks/frontend-alarms-runbook.md
@@ -8,6 +8,7 @@ This runbook covers the following second line production alarms for the Account 
 - [FrontendApiGatewayTrafficAnomalyAlarm](#frontendapigatewaytrafficanomalyalarm)
 - [FrontendLambdaErrorsAlarm](#frontendlambdaerrorsalarm)
 - [FrontendLambdaLogErrorAlarm](#frontendlambdalogerroralarm)
+- [FrontendLambdaColdStartDurationAnomalyAlarm](#frontendlambdacoldstartdurationanomalyalarm)
 
 These alarms are owned by the **Home team** in the **Accounts pod**.
 
@@ -111,3 +112,14 @@ These alarms may indicate a P3 incident. Out-of-hours escalation and support is 
 4. Check whether the errors correlate with a specific route or journey step.
 5. Check downstream service health (Auth, Home, external APIs).
 6. Check whether a recent deployment correlates with the start of errors.
+
+### FrontendLambdaColdStartDurationAnomalyAlarm
+
+**What it means:** The p90 cold start duration (`InitDuration`) of the Frontend Lambda has exceeded the anomaly detection band — i.e. it is significantly higher than the ML-modelled baseline. This may indicate a dependency being initialised during cold starts is slower than usual, or that a recent deployment has increased initialisation time.
+
+**Investigation steps:**
+
+1. Check the `amc-dashboard` CloudWatch dashboard — the "Frontend lambda cold start duration (p90) in milliseconds" widget shows the trend over time.
+2. Check whether a recent deployment correlates with the increase — a larger bundle size or new initialisation-time dependencies can increase cold start duration.
+3. Check Lambda metrics for memory pressure or CPU throttling which could slow initialisation.
+4. If cold start durations are consistently elevated after a deployment, consider whether the change can be optimised to reduce initialisation work.

--- a/solutions/app-infra/template.yaml
+++ b/solutions/app-infra/template.yaml
@@ -2010,6 +2010,35 @@ Resources:
       AlarmActions:
         - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
+  ApiTokenLambdaColdStartDurationAnomalyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProduction
+    Properties:
+      AlarmDescription: "AMC token lambda cold start durations have increased significantly above what is expected. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/api-alarms-runbook.md"
+      Metrics:
+        - Id: initDuration
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: InitDuration
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref ApiTokenLambda
+            Period: 300
+            Stat: p90
+          ReturnData: true
+        - Id: band
+          Expression: ANOMALY_DETECTION_BAND(initDuration, 2)
+          ReturnData: true
+      ComparisonOperator: GreaterThanUpperThreshold
+      ThresholdMetricId: band
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      TreatMissingData: notBreaching
+      ActionsEnabled: false
+      AlarmActions:
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+
   ApiTokenLambdaLogWarnByContextMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -2194,6 +2223,35 @@ Resources:
       Threshold: 1000
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
+      AlarmActions:
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+
+  ApiJourneyOutcomeLambdaColdStartDurationAnomalyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProduction
+    Properties:
+      AlarmDescription: "AMC journey outcome lambda cold start durations have increased significantly above what is expected. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/api-alarms-runbook.md"
+      Metrics:
+        - Id: initDuration
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: InitDuration
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref ApiJourneyOutcomeLambda
+            Period: 300
+            Stat: p90
+          ReturnData: true
+        - Id: band
+          Expression: ANOMALY_DETECTION_BAND(initDuration, 2)
+          ReturnData: true
+      ComparisonOperator: GreaterThanUpperThreshold
+      ThresholdMetricId: band
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      TreatMissingData: notBreaching
+      ActionsEnabled: false
       AlarmActions:
         - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 
@@ -2895,6 +2953,35 @@ Resources:
       Threshold: 1000
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
+      AlarmActions:
+        - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
+
+  FrontendLambdaColdStartDurationAnomalyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProduction
+    Properties:
+      AlarmDescription: "AMC frontend lambda cold start durations have increased significantly above what is expected. Runbook: https://github.com/govuk-one-login/account-components/blob/main/runbooks/frontend-alarms-runbook.md"
+      Metrics:
+        - Id: initDuration
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: InitDuration
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref FrontendLambda
+            Period: 300
+            Stat: p90
+          ReturnData: true
+        - Id: band
+          Expression: ANOMALY_DETECTION_BAND(initDuration, 2)
+          ReturnData: true
+      ComparisonOperator: GreaterThanUpperThreshold
+      ThresholdMetricId: band
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      TreatMissingData: notBreaching
+      ActionsEnabled: false
       AlarmActions:
         - Fn::ImportValue: !Sub ${AlertsStackName}-WarningAlertsTopicArn
 


### PR DESCRIPTION
Adds anomaly detection alarms for lambda cold start duration increases. These alarms are only present in production. The alarm actions are currently disabled whilst CloudWatch learns about what is normal. They will be enabled in a few weeks time. These alarms will send alerts to the `di-one-login-amc-warning-notifications` Slack channel.