### PR TITLE
BAU: enforce coverage thresholds

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -98,7 +98,7 @@ jobs:
         run: npm run build:all
 
       - name: Test
-        run: npm run test
+        run: npm run test:coverage
 
       - name: Deploy
         uses: govuk-one-login/devplatform-upload-action@64e46134b4108ebfa1cf2a64fee00782f8e2e8cf

--- a/.github/workflows/local-tests-unit.yaml
+++ b/.github/workflows/local-tests-unit.yaml
@@ -29,4 +29,4 @@ jobs:
         run: npm run install-all
 
       - name: Test
-        run: npm run test
+        run: npm run test:coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,7 +133,7 @@ repos:
     hooks:
       - id: test
         name: Test
-        entry: npm run test
+        entry: npm run test:coverage
         language: system
         exclude: .*
         always_run: true

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ There are various commands which can be run manually and which may also be run b
 - `npm run build:all` to build everything
 - `npm run test` to run [Vitest](https://vitest.dev/) tests
 - `npm run test:watch` to run [Vitest](https://vitest.dev/) tests in watch mode
-- `npm run test:coverage` to run [Vitest](https://vitest.dev/) tests and report coverage
+- `npm run test:coverage` to run [Vitest](https://vitest.dev/) tests and check coverage
 - `npm run check-types` to run [TypeScript](https://www.typescriptlang.org/) type checking
 - `npm run format` to run [Prettier](https://prettier.io/) formatting
 - `npm run eslint` to run [ESLint](https://eslint.org/)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,12 +9,20 @@ export default defineConfig({
     },
     coverage: {
       include: ["solutions/**/*.ts"],
+      exclude: [
+        "solutions/integration-tests/**",
+        "solutions/frontend/rolldown.config.ts",
+        "solutions/frontend/rolldown.local.config.ts",
+        "solutions/frontend/src/local.ts",
+        "solutions/frontend/src/lambda.ts",
+        "solutions/frontend/src/index.ts",
+      ],
       reporter: ["lcov", "text"],
       thresholds: {
-        lines: 90,
-        functions: 90,
-        branches: 90,
-        statements: 90,
+        lines: 85,
+        functions: 85,
+        branches: 85,
+        statements: 85,
       },
     },
     server: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
     coverage: {
       include: ["solutions/**/*.ts"],
       reporter: ["lcov", "text"],
+      thresholds: {
+        lines: 90,
+        functions: 90,
+        branches: 90,
+        statements: 90,
+      },
     },
     server: {
       deps: {


### PR DESCRIPTION
Enforce code coverage thresholds using Vitest so we aren't only relying on Sonar for this. This increases compliance with MAIN010 - https://govukverify.atlassian.net/wiki/spaces/DID/pages/3293249563/Reliability