### PR TITLE
BAU: disabled TGW disaster recovery

### DIFF
--- a/solutions/infra/variables.tf
+++ b/solutions/infra/variables.tf
@@ -168,6 +168,12 @@ variable "transit_gateway_hub_account_id" {
   description = "Transit Gateway Hub AWS Account ID where the Lambda execution role lives."
 }
 
+variable "transit_gateway_use_disaster_recovery" {
+  type        = bool
+  description = "Whether to use Transit Gateway disaster recovery."
+  default     = false
+}
+
 variable "disaster_recovery_transit_gateway_hub_account_id" {
   type        = string
   description = "Disaster recovery Transit Gateway Hub AWS Account ID where the Lambda execution role lives."

--- a/solutions/infra/vpc.tf
+++ b/solutions/infra/vpc.tf
@@ -19,7 +19,7 @@ resource "aws_cloudformation_stack" "spoke_vpc_stack" {
   parameters = {
     TransitGatewayId                 = var.transit_gateway_id
     DisasterRecoveryTransitGatewayId = var.disaster_recovery_transit_gateway_id
-    UseDisasterRecovery              = var.disaster_recovery_transit_gateway_id != null ? "Yes" : "No"
+    UseDisasterRecovery              = var.disaster_recovery_transit_gateway_hub_account_id != null && var.disaster_recovery_transit_gateway_id != null && var.transit_gateway_use_disaster_recovery ? "Yes" : "No"
     CloudWatchApiEnabled             = "Yes"
     CloudFormationEndpointEnabled    = contains(["dev", "build"], var.environment) ? "Yes" : "No" # Required for integration tests to run when inside the VPC
     CloudWatchLogsApiEnabled         = contains(["dev", "build"], var.environment) ? "Yes" : "No" # Required for integration tests to run when inside the VPC


### PR DESCRIPTION
Disables transit gateway disaster recovery in production. This should only be enabled in a disaster situation where the primary account and gateway are not working.