### PR TITLE
BAU: pin dev platform stacks to major versions

### DIFF
--- a/solutions/infra/api_gateway_logs.tf
+++ b/solutions/infra/api_gateway_logs.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudformation_stack" "api_gateway_logs_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377037345/API+gateway+logging
   name         = "api-gateway-logs"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/api-gateway-logs/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/api-gateway-logs/template-v1.yaml"
 
   capabilities = ["CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
 }

--- a/solutions/infra/build_notifications.tf
+++ b/solutions/infra/build_notifications.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudformation_stack" "build_notifications_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377168419/Slack+build+notifications+-+via+AWS+Chatbot
   name         = "build-notifications"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/build-notifications/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/build-notifications/template-v2.yaml"
 
   parameters = {
     BuildNotificationSlackChannelId = var.environment == "production" ? "C0ALMLUAZE3" : "C0AMXCUQEQG"

--- a/solutions/infra/certificate_expiry.tf
+++ b/solutions/infra/certificate_expiry.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudformation_stack" "certificate_expiry_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3374843054/Certificate+Expiry
   name         = "certificate-expiry"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate-expiry/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate-expiry/template-v1.yaml"
 
   parameters = {
     DaysBeforeExpiry = 45

--- a/solutions/infra/certificates.tf
+++ b/solutions/infra/certificates.tf
@@ -2,7 +2,7 @@ resource "aws_cloudformation_stack" "certificate_stack_virginia" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/4028006740/certificate+readme
   provider     = aws.virginia
   name         = "certificate"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate/template-v1.yaml"
 
   parameters = {
     DomainName   = var.hosted_zone_domain
@@ -13,7 +13,7 @@ resource "aws_cloudformation_stack" "certificate_stack_virginia" {
 resource "aws_cloudformation_stack" "certificate_stack_london" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/4028006740/certificate+readme
   name         = "certificate"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/certificate/template-v1.yaml"
 
   parameters = {
     DomainName           = var.hosted_zone_domain

--- a/solutions/infra/cloudfront.tf
+++ b/solutions/infra/cloudfront.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudformation_stack" "main_cloudfront_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/4035936392/cloudfront-distribution+readme
   name         = "cloudfront"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-distribution/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/cloudfront-distribution/template-v3.yaml"
 
   parameters = {
     DistributionAlias                                             = var.hosted_zone_domain

--- a/solutions/infra/ecr_integration_tests.tf
+++ b/solutions/infra/ecr_integration_tests.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudformation_stack" "test_image_repository" {
   name         = "test-image-ecr"
   count        = contains(["build", "dev"], var.environment) ? 1 : 0
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/test-image-repository/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/test-image-repository/template-v1.yaml"
   capabilities = ["CAPABILITY_NAMED_IAM"]
   parameters = {
     PipelineStackName  = "pipeline-amc"

--- a/solutions/infra/ecr_scan_logger.tf
+++ b/solutions/infra/ecr_scan_logger.tf
@@ -2,7 +2,7 @@ resource "aws_cloudformation_stack" "ecr_scan_logger_stack" {
   count = var.create_build_stacks ? 1 : 0
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377102896/ECR+Scan+Result+Logger
   name         = "ecr-image-scan-findings-logger"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/ecr-image-scan-findings-logger/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/ecr-image-scan-findings-logger/template-v1.yaml"
 
   parameters = {
     NotificationEmail = var.owner_email

--- a/solutions/infra/github_identity_provider.tf
+++ b/solutions/infra/github_identity_provider.tf
@@ -2,7 +2,7 @@ resource "aws_cloudformation_stack" "github_identity_provider_stack" {
   count = var.create_build_stacks ? 1 : 0
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3375464923/GitHub+Identity+Provider
   name         = "github-identity-provider"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/github-identity/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/github-identity/template-v1.yaml"
 
   parameters = {
     Environment = var.environment

--- a/solutions/infra/pipelines.tf
+++ b/solutions/infra/pipelines.tf
@@ -2,7 +2,7 @@
 
 resource "aws_cloudformation_stack" "amc_pipeline_stack" {
   name         = "pipeline-amc"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/sam-deploy-pipeline/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/sam-deploy-pipeline/template-v2.yaml"
 
   parameters = {
     SAMStackName                            = "amc"

--- a/solutions/infra/signer.tf
+++ b/solutions/infra/signer.tf
@@ -2,7 +2,7 @@ resource "aws_cloudformation_stack" "signer_stack" {
   count = var.create_build_stacks ? 1 : 0
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3377004573/AWS+Signer
   name         = "signer"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/signer/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/signer/template-v1.yaml"
 
   parameters = {
     Environment = var.environment
@@ -16,7 +16,7 @@ resource "aws_cloudformation_stack" "container_signer_stack" {
   count = var.create_build_stacks ? 1 : 0
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3376840727/Container+Signer
   name         = "container-signer"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/container-signer/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.amazonaws.com/container-signer/template-v1.yaml"
 
   parameters = {
     Environment     = var.environment

--- a/solutions/infra/vpc.tf
+++ b/solutions/infra/vpc.tf
@@ -14,7 +14,7 @@ resource "aws_cloudformation_stack" "transit_gateway_cross_account_role" {
 resource "aws_cloudformation_stack" "spoke_vpc_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5746426210/Transit+Gateway+Infrastructure+Reference#Latest-published-templates
   name         = "vpc"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/spoke-vpc/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/spoke-vpc/template-v2.0.6.yaml"
 
   parameters = {
     TransitGatewayId                 = var.transit_gateway_id

--- a/solutions/infra/vpc.tf
+++ b/solutions/infra/vpc.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudformation_stack" "transit_gateway_cross_account_role" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5746426210/Transit+Gateway+Infrastructure+Reference#Latest-published-templates
   name         = "transit-gateway-cross-account-role"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/tgw-cross-account-role/template.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/tgw-cross-account-role/template-v2.yaml"
 
   parameters = {
     HubAccountId                 = var.transit_gateway_hub_account_id
@@ -14,7 +14,7 @@ resource "aws_cloudformation_stack" "transit_gateway_cross_account_role" {
 resource "aws_cloudformation_stack" "spoke_vpc_stack" {
   # See https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/5746426210/Transit+Gateway+Infrastructure+Reference#Latest-published-templates
   name         = "vpc"
-  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/spoke-vpc/template-v2.0.6.yaml"
+  template_url = "https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/spoke-vpc/template-v2.yaml"
 
   parameters = {
     TransitGatewayId                 = var.transit_gateway_id


### PR DESCRIPTION
Pin the dev platform stacks to the major version to prevent accidentally deploying breaking changes