### PR TITLE
BAU: enrolment failure audit event fix

### DIFF
--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.test.ts
@@ -492,6 +492,7 @@ describe("passkey-create handlers", () => {
           },
           type: "public-key",
         },
+        undefined,
         "ErrorGettingExistingPasskeysForUser",
       );
     });
@@ -705,7 +706,7 @@ describe("passkey-create handlers", () => {
         );
         expect(
           mockSendPasskeyRegistrationFailedAuditEvent,
-        ).toHaveBeenCalledWith(mockRequest, mockReply);
+        ).toHaveBeenCalledWith(mockRequest, mockReply, "UnknownError");
         expect(
           mockSendPasskeyRegistrationFailedAuditEvent,
         ).toHaveBeenCalledTimes(1);
@@ -713,6 +714,8 @@ describe("passkey-create handlers", () => {
           mockRequest,
           mockReply,
           { challenge: "test-challenge" },
+          undefined,
+          "UnknownError",
         );
       });
     });
@@ -983,6 +986,7 @@ describe("passkey-create handlers", () => {
             },
             type: "public-key",
           },
+          undefined,
           "VerificationError - Verification error",
         );
         expect(mockReply.render).toHaveBeenCalledWith(
@@ -1040,6 +1044,7 @@ describe("passkey-create handlers", () => {
             },
             type: "public-key",
           },
+          undefined,
           "VerificationFailed",
         );
         expect(mockReply.render).toHaveBeenCalledWith(
@@ -1126,6 +1131,7 @@ describe("passkey-create handlers", () => {
             },
             type: "public-key",
           },
+          undefined,
           "ErrorSavingPasskey",
         );
       });
@@ -1186,6 +1192,8 @@ describe("passkey-create handlers", () => {
           mockRequest,
           mockReply,
           { challenge: "test-challenge" },
+          undefined,
+          "UnknownError",
         );
       });
 
@@ -1346,6 +1354,7 @@ describe("passkey-create handlers", () => {
           mockReply,
           { challenge: "test-challenge" },
           {},
+          undefined,
           "UserHasMaximumNumberOfPasskeys",
         );
         expect(mockReply.render).toHaveBeenCalledWith(

--- a/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
+++ b/solutions/frontend/src/journeys/passkey-create/handlers/create.ts
@@ -254,11 +254,17 @@ export async function postHandler(
       reason: invalidRequestBodyErrorReason,
     };
 
-    await sendPasskeyRegistrationFailedAuditEvent(request, reply);
+    await sendPasskeyRegistrationFailedAuditEvent(
+      request,
+      reply,
+      "UnknownError",
+    );
     await sendPasskeyEnrolmentFailedAuditEvent(
       request,
       reply,
       registrationOptions,
+      undefined,
+      "UnknownError",
     );
 
     await render(request, reply, {
@@ -325,6 +331,8 @@ export async function postHandler(
       request,
       reply,
       registrationOptions,
+      undefined,
+      reason,
     );
 
     await render(request, reply, {
@@ -362,6 +370,7 @@ export async function postHandler(
       reply,
       registrationOptions,
       body.registrationResponse,
+      undefined,
       `VerificationError${error instanceof Error ? " - " + error.message : ""}`,
     );
 
@@ -380,6 +389,7 @@ export async function postHandler(
       reply,
       registrationOptions,
       body.registrationResponse,
+      undefined,
       "VerificationFailed",
     );
 
@@ -412,6 +422,7 @@ export async function postHandler(
       reply,
       registrationOptions,
       body.registrationResponse,
+      undefined,
       "ErrorGettingExistingPasskeysForUser",
     );
 
@@ -431,6 +442,7 @@ export async function postHandler(
       reply,
       registrationOptions,
       body.registrationResponse,
+      undefined,
       "UserHasMaximumNumberOfPasskeys",
     );
 
@@ -489,6 +501,7 @@ export async function postHandler(
       reply,
       registrationOptions,
       body.registrationResponse,
+      undefined,
       "ErrorSavingPasskey",
     );
 

--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.test.ts
@@ -482,6 +482,7 @@ describe("passkey-create audit events", () => {
         mockReply as FastifyReply,
         registrationOptions as PublicKeyCredentialCreationOptionsJSON,
         registrationResponse,
+        undefined,
         "UserVerificationError",
       );
 
@@ -579,6 +580,7 @@ describe("passkey-create audit events", () => {
         registrationOptions as PublicKeyCredentialCreationOptionsJSON,
         registrationResponse,
         undefined,
+        undefined,
       );
 
       const eventPayload = mockCreateEvent.mock.calls[0]?.[1];
@@ -598,6 +600,7 @@ describe("passkey-create audit events", () => {
           excludeCredentials: undefined,
         } as unknown as PublicKeyCredentialCreationOptionsJSON,
         registrationResponse,
+        undefined,
         "UserVerificationError",
       );
 
@@ -622,6 +625,7 @@ describe("passkey-create audit events", () => {
         mockReply as FastifyReply,
         registrationOptions as PublicKeyCredentialCreationOptionsJSON,
         registrationResponse,
+        undefined,
         "UserVerificationError",
       );
 
@@ -637,6 +641,7 @@ describe("passkey-create audit events", () => {
           mockReply as FastifyReply,
           registrationOptions as PublicKeyCredentialCreationOptionsJSON,
           registrationResponse,
+          undefined,
           "UserVerificationError",
         ),
       ).rejects.toThrow();

--- a/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
+++ b/solutions/frontend/src/journeys/passkey-create/utils/auditEvents/index.ts
@@ -177,7 +177,7 @@ export const sendPasskeyRegistrationGeneratedAuditEvent = async (
 export const sendPasskeyRegistrationFailedAuditEvent = async (
   request: FastifyRequest,
   reply: FastifyReply,
-  reason: (typeof passkeyRegistrationFailureReason)[number] = "UnknownError",
+  reason: (typeof passkeyRegistrationFailureReason)[number],
 ) => {
   const base = getBaseEventProps(request, reply);
   if (!base) return;
@@ -243,7 +243,8 @@ export const sendPasskeyEnrolmentFailedAuditEvent = async (
   registrationResponse?: InferOutput<
     typeof postBodySchema
   >["registrationResponse"],
-  reason?: string,
+  registrationFailureReason?: (typeof passkeyRegistrationFailureReason)[number],
+  enrolmentFailureReason?: string,
 ) => {
   const base = getBaseEventProps(request, reply);
   if (!base) return;
@@ -264,10 +265,12 @@ export const sendPasskeyEnrolmentFailedAuditEvent = async (
         }),
         passkey: {
           ...enrolment.extensions,
-          ...(registrationResponse !== undefined &&
-            reason !== undefined && {
-              passkey_enrolment_failure_reason: reason,
-            }),
+          ...(enrolmentFailureReason !== undefined && {
+            passkey_enrolment_failure_reason: enrolmentFailureReason,
+          }),
+          ...(registrationFailureReason !== undefined && {
+            passkey_registration_failure_reason: registrationFailureReason,
+          }),
         },
       },
       restricted: {


### PR DESCRIPTION
Refactors the `sendPasskeyEnrolmentFailedAuditEvent` audit event function to separate registration and enrolment failure reasons into distinct parameters (`registrationFailureReason` and `enrolmentFailureReason`), replacing the previous single reason field. This allows both failure reasons to be emitted independently in the event payload. `sendPasskeyRegistrationFailedAuditEvent` is also updated to require its reason argument explicitly rather than defaulting to "UnknownError". All call sites in the post handler and corresponding tests are updated accordingly.