### PR TITLE
BAU: fix CSP form action

### DIFF
--- a/solutions/frontend/src/index.ts
+++ b/solutions/frontend/src/index.ts
@@ -244,10 +244,7 @@ export const initFrontend = async function () {
           "https://*.ruxit.com",
           "https://*.dynatrace.com",
         ],
-        formAction:
-          getEnvironment() === "local"
-            ? ["'self'", "http://localhost:*"]
-            : ["'self'", "https://*.account.gov.uk"],
+        formAction: null,
         ...(getEnvironment() === "local"
           ? {
               upgradeInsecureRequests: null,


### PR DESCRIPTION
Set the CSP form action to null. This will allow form actions to any domain. This is necessary because the CSP applies to the whole redirect chain and it is possible for the redirect chain to redirect the RP's callback URL. At the moment these redirects are being blocked because RPs' callback URLs don't match the form action value `"'self'", "https://*.account.gov.uk"`.