### PR TITLE
BAU: extract and comment CSP config

### DIFF
--- a/solutions/frontend/src/index.ts
+++ b/solutions/frontend/src/index.ts
@@ -12,11 +12,7 @@ import cy from "./translations/cy.json" with { type: "json" };
 import { getSessionOptions } from "./utils/session.js";
 import fastifyStatic from "@fastify/static";
 import * as path from "node:path";
-import {
-  channelCookieName,
-  Lang,
-  oneYearInSeconds,
-} from "../../commons/utils/constants.js";
+import { channelCookieName, Lang } from "../../commons/utils/constants.js";
 import staticHash from "./utils/static-hash.json" with { type: "json" };
 import simpleWebAuthNBrowserStaticHash from "./utils/static-hash-simplewebauthn-browser.json" with { type: "json" };
 import staticHashGovUkFrontendAssets from "./utils/static-hash-govuk-frontend-assets.json" with { type: "json" };
@@ -43,6 +39,7 @@ import { resolveEnvVarToBool } from "../../commons/utils/resolveEnvVarToBool/ind
 import { simpleUnsuccessfulJourneyActionErrors } from "./journeys/utils/journeyActions.js";
 import { setAnalyticsForPath } from "./utils/setAnalyticsForPath/index.js";
 import { FastifyLogController } from "../../commons/utils/fastify/logController/index.js";
+import { getHelmetConfig } from "./utils/getHelmetConfig.js";
 
 await configureI18n({
   [Lang.English]: {
@@ -214,60 +211,7 @@ export const initFrontend = async function () {
   });
 
   fastify.register(fastifyFormbody);
-  fastify.register(fastifyHelmet, {
-    enableCSPNonces: true,
-    contentSecurityPolicy: {
-      directives: {
-        defaultSrc: ["'self'"],
-        scriptSrc: [
-          "'self'",
-          "https://*.googletagmanager.com",
-          "https://*.google-analytics.com",
-          "https://*.analytics.google.com",
-          "https://*.ruxit.com",
-          "https://*.dynatrace.com",
-        ],
-        imgSrc: [
-          "'self'",
-          "data:",
-          "https://*.googletagmanager.com",
-          "https://*.google-analytics.com",
-          "https://*.analytics.google.com",
-          "https://*.g.doubleclick.net",
-        ],
-        objectSrc: ["'none'"],
-        connectSrc: [
-          "'self'",
-          "https://*.google-analytics.com",
-          "https://*.analytics.google.com",
-          "https://*.g.doubleclick.net",
-          "https://*.ruxit.com",
-          "https://*.dynatrace.com",
-        ],
-        formAction: null,
-        ...(getEnvironment() === "local"
-          ? {
-              upgradeInsecureRequests: null,
-            }
-          : {}),
-      },
-    },
-    dnsPrefetchControl: {
-      allow: false,
-    },
-    frameguard: {
-      action: "deny",
-    },
-    hsts: {
-      maxAge: oneYearInSeconds,
-      preload: true,
-      includeSubDomains: true,
-    },
-    referrerPolicy: false,
-    permittedCrossDomainPolicies: {
-      permittedPolicies: "none",
-    },
-  });
+  fastify.register(fastifyHelmet, getHelmetConfig());
 
   fastify.register(async (fastify) => {
     fastify.register(fastifySession, await getSessionOptions());

--- a/solutions/frontend/src/utils/getHelmetConfig.test.ts
+++ b/solutions/frontend/src/utils/getHelmetConfig.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { getHelmetConfig } from "./getHelmetConfig.js";
+import { oneYearInSeconds } from "../../../commons/utils/constants.js";
+
+vi.mock(import("../../../commons/utils/getEnvironment/index.js"), () => ({
+  getEnvironment: vi.fn(),
+}));
+
+import { getEnvironment } from "../../../commons/utils/getEnvironment/index.js";
+
+describe("getHelmetConfig", () => {
+  beforeEach(() => {
+    vi.mocked(getEnvironment).mockReturnValue("production");
+  });
+
+  it("should enable CSP nonces", () => {
+    expect(getHelmetConfig().enableCSPNonces).toBe(true);
+  });
+
+  it("should set correct CSP directives", () => {
+    const { directives } = getHelmetConfig().contentSecurityPolicy as {
+      directives: Record<string, unknown>;
+    };
+
+    expect(directives["defaultSrc"]).toStrictEqual(["'self'"]);
+    expect(directives["objectSrc"]).toStrictEqual(["'none'"]);
+    expect(directives["formAction"]).toBeNull();
+    expect(directives["scriptSrc"]).toContain("'self'");
+    expect(directives["imgSrc"]).toContain("'self'");
+    expect(directives["connectSrc"]).toContain("'self'");
+  });
+
+  it("should not include upgradeInsecureRequests in non-local environments", () => {
+    const { directives } = getHelmetConfig().contentSecurityPolicy as {
+      directives: Record<string, unknown>;
+    };
+
+    expect(directives).not.toHaveProperty("upgradeInsecureRequests");
+  });
+
+  it("should include upgradeInsecureRequests: null in local environment", () => {
+    vi.mocked(getEnvironment).mockReturnValue("local");
+
+    const { directives } = getHelmetConfig().contentSecurityPolicy as {
+      directives: Record<string, unknown>;
+    };
+
+    expect(directives["upgradeInsecureRequests"]).toBeNull();
+  });
+
+  it("should disable DNS prefetch", () => {
+    expect(getHelmetConfig().dnsPrefetchControl).toStrictEqual({
+      allow: false,
+    });
+  });
+
+  it("should deny framing", () => {
+    expect(getHelmetConfig().frameguard).toStrictEqual({ action: "deny" });
+  });
+
+  it("should set HSTS with one year max age, preload and includeSubDomains", () => {
+    expect(getHelmetConfig().hsts).toStrictEqual({
+      maxAge: oneYearInSeconds,
+      preload: true,
+      includeSubDomains: true,
+    });
+  });
+
+  it("should disable referrer policy", () => {
+    expect(getHelmetConfig().referrerPolicy).toBe(false);
+  });
+
+  it("should set permittedCrossDomainPolicies to none", () => {
+    expect(getHelmetConfig().permittedCrossDomainPolicies).toStrictEqual({
+      permittedPolicies: "none",
+    });
+  });
+});

--- a/solutions/frontend/src/utils/getHelmetConfig.ts
+++ b/solutions/frontend/src/utils/getHelmetConfig.ts
@@ -1,0 +1,66 @@
+import type { FastifyHelmetOptions } from "@fastify/helmet";
+import { oneYearInSeconds } from "../../../commons/utils/constants.js";
+import { getEnvironment } from "../../../commons/utils/getEnvironment/index.js";
+
+export const getHelmetConfig = (): FastifyHelmetOptions => {
+  return {
+    enableCSPNonces: true,
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: [
+          "'self'",
+          "https://*.googletagmanager.com",
+          "https://*.google-analytics.com",
+          "https://*.analytics.google.com",
+          "https://*.ruxit.com",
+          "https://*.dynatrace.com",
+        ],
+        imgSrc: [
+          "'self'",
+          "data:",
+          "https://*.googletagmanager.com",
+          "https://*.google-analytics.com",
+          "https://*.analytics.google.com",
+          "https://*.g.doubleclick.net",
+        ],
+        objectSrc: ["'none'"],
+        connectSrc: [
+          "'self'",
+          "https://*.google-analytics.com",
+          "https://*.analytics.google.com",
+          "https://*.g.doubleclick.net",
+          "https://*.ruxit.com",
+          "https://*.dynatrace.com",
+        ],
+        /*
+        formAction must be null because it is possible to submit a form in AMC
+        and go through a redirect chain directly to an RP callback URL on a domain
+        which we don't control. There are lots of RP callback URLs and they are often
+        being added/updated/deleted and so it is not possible to allowlist them all.
+        */
+        formAction: null,
+        ...(getEnvironment() === "local"
+          ? {
+              upgradeInsecureRequests: null,
+            }
+          : {}),
+      },
+    },
+    dnsPrefetchControl: {
+      allow: false,
+    },
+    frameguard: {
+      action: "deny",
+    },
+    hsts: {
+      maxAge: oneYearInSeconds,
+      preload: true,
+      includeSubDomains: true,
+    },
+    referrerPolicy: false,
+    permittedCrossDomainPolicies: {
+      permittedPolicies: "none",
+    },
+  };
+};


### PR DESCRIPTION
Extracts the frontend CSP config into its own file, adds unit tests to assert the config is as expected and adds a comment explaining why `formAction` is set to `null`.