### PR TITLE
BAU: Bump cookie to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "@smithy/node-http-handler": "^4.7.1",
         "aws-xray-sdk": "^3.12.0",
         "axios": "^1.18.1",
-        "cookie": "^1.1.1",
+        "cookie": "^2.0.1",
         "ecdsa-sig-formatter": "^1.0.11",
         "esbuild": "^0.28.1",
         "fastify": "^5.10.0",
@@ -1394,19 +1394,6 @@
       "dependencies": {
         "cookie": "^2.0.0",
         "fastify-plugin": "^6.0.0"
-      }
-    },
-    "node_modules/@fastify/cookie/node_modules/cookie": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
-      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/@fastify/csrf": {
@@ -4863,10 +4850,12 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "1.1.1",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-2.0.1.tgz",
+      "integrity": "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "funding": {
         "type": "opencollective",
@@ -6550,6 +6539,19 @@
         "cookie": "^1.0.1",
         "process-warning": "^4.0.0",
         "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/light-my-request/node_modules/process-warning": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@smithy/node-http-handler": "^4.7.1",
     "aws-xray-sdk": "^3.12.0",
     "axios": "^1.18.1",
-    "cookie": "^1.1.1",
+    "cookie": "^2.0.1",
     "ecdsa-sig-formatter": "^1.0.11",
     "esbuild": "^0.28.1",
     "fastify": "^5.10.0",

--- a/solutions/commons/utils/getPropsFromAPIGatewayEvent/index.ts
+++ b/solutions/commons/utils/getPropsFromAPIGatewayEvent/index.ts
@@ -1,8 +1,8 @@
 import type { APIGatewayProxyEvent } from "aws-lambda";
-import { parse } from "cookie";
+import { parseCookie } from "cookie";
 
 export const getPropsFromAPIGatewayEvent = (event: APIGatewayProxyEvent) => {
-  const cookies = parse(event.headers["cookie"] ?? "");
+  const cookies = parseCookie(event.headers["cookie"] ?? "");
   const gsCookie = cookies["gs"];
   const gsCookieParts = gsCookie ? gsCookie.split(".") : [];
 


### PR DESCRIPTION
Checks are failing on the [dependabot pr](https://github.com/govuk-one-login/account-components/pull/1031) updating the version of `cookie`. This implements the breaking update manually.